### PR TITLE
Add None-safe XLSX handling and enhance error logging/debugging

### DIFF
--- a/pyhindsight/analysis.py
+++ b/pyhindsight/analysis.py
@@ -6,6 +6,9 @@ import os
 import sqlite3
 import sys
 import time
+import uuid
+import xlsxwriter
+import xlsxwriter.worksheet
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from pyhindsight import __version__
@@ -23,6 +26,35 @@ import rich.table
 import rich.text
 
 log = logging.getLogger(__name__)
+
+class NoneSafeWorksheet(xlsxwriter.worksheet.Worksheet):
+    """Worksheet that renders a None value as an empty (but still formatted) cell.
+
+    xlsxwriter's typed writers raise on None -- write_string() does len(None) and
+    write_number() does isnan(None). The XLSX sheets are written column by column
+    inside a single try/except per row, so an unguarded None used to abort the row
+    *partway through*: the columns already written stayed in place and every column
+    after it was silently dropped, leaving a truncated row that still looked complete.
+
+    None is legitimate in this data rather than a parsing failure. Firefox stores NULL
+    in moz_places.title (it has no empty-string titles at all), and items read from
+    flat JSON -- e.g. an extension's DNR rules.json -- have no LevelDB seq or offset.
+    Those are absences at the source, so they are written as empty cells instead of
+    being coerced to '' or 0, which would invent a value the artifact does not contain.
+    """
+
+    # convert_cell_args preserves the base class's support for A1 notation.
+    @xlsxwriter.worksheet.convert_cell_args
+    def write_string(self, row, col, string=None, cell_format=None):
+        if string is None:
+            return self.write_blank(row, col, None, cell_format)
+        return super().write_string(row, col, string, cell_format)
+
+    @xlsxwriter.worksheet.convert_cell_args
+    def write_number(self, row, col, number=None, cell_format=None):
+        if number is None:
+            return self.write_blank(row, col, None, cell_format)
+        return super().write_number(row, col, number, cell_format)
 
 
 class HindsightEncoder(json.JSONEncoder):
@@ -793,7 +825,23 @@ class AnalysisSession(object):
         elif self.timezone is None:
             self.timezone = datetime.timezone.utc
 
-        log.debug("Options: " + str(self.__dict__))
+        # Give this run its own subdirectory of the temp directory. Copies inside it are
+        # named only after the database (<temp_dir>/History), and the default temp path is
+        # a fixed location next to the binary, so two Hindsight runs at once would write
+        # to the same <temp_dir>/History and each could end up parsing the other's profile
+        # data -- or delete the directory while the other was still reading from it.
+        # Isolating per run also keeps each run's cleanup from touching another's files.
+        if self.temp_dir:
+            self.temp_dir = os.path.join(self.temp_dir, f'run-{os.getpid()}-{uuid.uuid4().hex[:8]}')
+
+        # Redact secret values before dumping the options. Log files are routinely
+        # attached to bug reports, so the key names are kept (useful for confirming
+        # which config was picked up) but the values never reach disk.
+        loggable_options = dict(self.__dict__)
+        if loggable_options.get('api_keys'):
+            loggable_options['api_keys'] = {
+                key_name: '<redacted>' for key_name in loggable_options['api_keys']}
+        log.debug("Options: " + str(loggable_options))
 
         # Normalize the optional -b/--browser_type override. When set, it forces a
         # single family for every discovered profile (case-insensitive); when unset,
@@ -1102,8 +1150,11 @@ class AnalysisSession(object):
                             sys.path.remove(potential_plugin_path)
 
     def generate_excel(self, output_object):
-        import xlsxwriter
         workbook = xlsxwriter.Workbook(output_object, {'in_memory': True, 'strings_to_urls': False})
+        # Applies to every add_worksheet() call below (xlsxwriter falls back to this
+        # attribute when no explicit worksheet_class is passed), so a None in any column
+        # blanks that cell instead of silently dropping the rest of the row.
+        workbook.worksheet_class = NoneSafeWorksheet
 
         # Track used sheet names to avoid duplicates
         used_sheet_names = set()
@@ -2258,69 +2309,66 @@ class AnalysisSession(object):
         sync_ws.freeze_panes(2, 0)  # Freeze top row
         sync_ws.autofilter(1, 0, row_number, 9)  # Add autofilter
 
+        def render_cell(value):
+            """Render a presentation value that xlsxwriter's write() can't take directly.
+
+            write() handles scalars only, and some preference values are dicts or lists
+            (e.g. a policy object). Those used to raise and, because the whole sheet was
+            built inside one try/except, cost every remaining row on that sheet. Rendering
+            them as JSON keeps the content instead of dropping it.
+            """
+            if isinstance(value, (dict, list)):
+                return json.dumps(value, sort_keys=True, default=str)
+            return value
+
+        def write_presentation_sheet(d, sheet_label):
+            """Render one plugin/preferences 'presentation' block as its own worksheet."""
+            sheet_name = get_unique_sheet_name(d['presentation']['title'])
+            p = workbook.add_worksheet(sheet_name)
+            title = d['presentation']['title']
+            if 'version' in d['presentation']:
+                title += f" (v{d['presentation']['version']})"
+            p.merge_range(0, 0, 0, len(d['presentation']['columns']) - 1,
+                          f"Hindsight Internet History Forensics (v{__version__}) - {title}",
+                          title_header_format)
+            for counter, column in enumerate(d['presentation']['columns']):
+                p.write(1, counter, column['display_name'], header_format)
+                if 'display_width' in column:
+                    p.set_column(counter, counter, column['display_width'])
+
+            for row_count, row in enumerate(d['data'], start=2):
+                # Caught per row, so one unrenderable value costs that row rather than
+                # silently truncating the sheet at that point.
+                try:
+                    for column_count, column in enumerate(d['presentation']['columns']):
+                        value = row[column['data_name']] if isinstance(row, dict) \
+                            else row.__dict__[column['data_name']]
+                        p.write(row_count, column_count, render_cell(value), black_type_format)
+                except Exception as e:
+                    log.warning(f'Failed to write row to {sheet_label} sheet "{sheet_name}": {e}')
+
+            # Formatting
+            p.freeze_panes(2, 0)  # Freeze top row
+            p.autofilter(1, 0, len(d['data']) + 2, len(d['presentation']['columns']) - 1)  # Add autofilter
+
         for item in self.__dict__:
+            # self.__dict__ holds every session attribute; only plugin result blocks have
+            # the {'presentation': ..., 'data': ...} shape. Select those explicitly rather
+            # than letting a bare except double as the type filter -- that swallowed real
+            # write failures too, and a whole sheet could vanish with nothing logged.
+            candidate = self.__dict__[item]
+            if not isinstance(candidate, dict) \
+                    or not candidate.get('presentation') or not candidate.get('data'):
+                continue
             try:
-                if self.__dict__[item]['presentation'] and self.__dict__[item]['data']:
-                    d = self.__dict__[item]
-                    sheet_name = get_unique_sheet_name(d['presentation']['title'])
-                    p = workbook.add_worksheet(sheet_name)
-                    title = d['presentation']['title']
-                    if 'version' in d['presentation']:
-                        title += f" (v{d['presentation']['version']})"
-                    p.merge_range(0, 0, 0, len(d['presentation']['columns']) - 1,
-                                  f"Hindsight Internet History Forensics (v{__version__}) - {title}",
-                                  title_header_format)
-                    for counter, column in enumerate(d['presentation']['columns']):
-                        # print column
-                        p.write(1, counter, column['display_name'], header_format)
-                        if 'display_width' in column:
-                            p.set_column(counter, counter, column['display_width'])
-
-                    for row_count, row in enumerate(d['data'], start=2):
-                        if not isinstance(row, dict):
-                            for column_count, column in enumerate(d['presentation']['columns']):
-                                p.write(row_count, column_count, row.__dict__[column['data_name']], black_type_format)
-                        else:
-                            for column_count, column in enumerate(d['presentation']['columns']):
-                                p.write(row_count, column_count, row[column['data_name']], black_type_format)
-
-                    # Formatting
-                    p.freeze_panes(2, 0)  # Freeze top row
-                    p.autofilter(1, 0, len(d['data']) + 2, len(d['presentation']['columns']) - 1)  # Add autofilter
-
+                write_presentation_sheet(candidate, 'plugin')
             except Exception as e:
-                pass
+                log.warning(f'Exception occurred while writing plugin page {item}: {e}')
 
-        # TODO: combine this with above function
         for item in self.__dict__.get('preferences'):
             try:
                 if item['presentation'] and item['data']:
-                    d = item
-                    sheet_name = get_unique_sheet_name(d['presentation']['title'])
-                    p = workbook.add_worksheet(sheet_name)
-                    title = d['presentation']['title']
-                    if 'version' in d['presentation']:
-                        title += f" (v{d['presentation']['version']})"
-                    p.merge_range(0, 0, 0, len(d['presentation']['columns']) - 1,
-                                  f"Hindsight Internet History Forensics (v{__version__}) - {title}",
-                                  title_header_format)
-                    for counter, column in enumerate(d['presentation']['columns']):
-                        p.write(1, counter, column['display_name'], header_format)
-                        if 'display_width' in column:
-                            p.set_column(counter, counter, column['display_width'])
-
-                    for row_count, row in enumerate(d['data'], start=2):
-                        if not isinstance(row, dict):
-                            for column_count, column in enumerate(d['presentation']['columns']):
-                                p.write(row_count, column_count, row.__dict__[column['data_name']], black_type_format)
-                        else:
-                            for column_count, column in enumerate(d['presentation']['columns']):
-                                p.write(row_count, column_count, row[column['data_name']], black_type_format)
-
-                    # Formatting
-                    p.freeze_panes(2, 0)  # Freeze top row
-                    p.autofilter(1, 0, len(d['data']) + 2, len(d['presentation']['columns']) - 1)  # Add autofilter
-
+                    write_presentation_sheet(item, 'Preferences')
             except Exception as e:
                 log.warning(f"Exception occurred while writing Preferences page: {e}")
 

--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -1984,7 +1984,12 @@ class Chrome(WebBrowser):
                             log.error(f' - ValueError ({e}) when processing {database}')
 
                         except Exception as e:
-                            log.error(f' - Unexpected Exception: {e}')
+                            # This aborts the rest of this object store's records, so name
+                            # what was being read and how far it got -- otherwise there is
+                            # no way to tell which data is missing from the output.
+                            log.error(f' - Unexpected Exception ({e}) when processing '
+                                      f'{database}.{obj_store_name}; '
+                                      f'{len(results)} records parsed before the failure')
             except ValueError as e:
                 log.error(f' - {e} when processing {storage_directory}')
                 continue
@@ -4676,7 +4681,9 @@ class Chrome(WebBrowser):
                 log.warning(f'KG API connection error: {e.reason}')
                 break
             except Exception as e:
-                log.warning(f'KG API error: {e}')
+                # The request URL carries the API key, and some exceptions echo it back;
+                # scrub it so the key can't reach the log via an error message.
+                log.warning(f'KG API error: {str(e).replace(api_key, "<redacted>")}')
                 break
 
         resolved_count = sum(1 for v in self.kg_entities.values() if v is not None)
@@ -5002,11 +5009,14 @@ class Chrome(WebBrowser):
 
         # Clean temp directory after processing profile
         if not self.no_copy:
-            log.info(f'Deleting temporary directory {self.temp_dir}')
-            try:
-                shutil.rmtree(self.temp_dir)
-            except Exception as e:
-                log.error(f'Exception deleting temporary directory: {e}')
+            # The directory is only created when a database is actually copied into it,
+            # so its absence is normal rather than an error worth reporting.
+            if os.path.isdir(self.temp_dir):
+                log.info(f'Deleting temporary directory {self.temp_dir}')
+                try:
+                    shutil.rmtree(self.temp_dir)
+                except Exception as e:
+                    log.error(f'Exception deleting temporary directory: {e}')
 
     class URLItem(WebBrowser.URLItem):
         def decode_transition(self):

--- a/tests/test_xlsx_none_safety.py
+++ b/tests/test_xlsx_none_safety.py
@@ -1,0 +1,92 @@
+import io
+import unittest
+
+import openpyxl
+import xlsxwriter
+import xlsxwriter.worksheet
+
+from pyhindsight.analysis import NoneSafeWorksheet
+
+
+def _build_workbook():
+    """Build a workbook wired up the way generate_excel() does."""
+    buffer = io.BytesIO()
+    workbook = xlsxwriter.Workbook(buffer, {'in_memory': True, 'strings_to_urls': False})
+    workbook.worksheet_class = NoneSafeWorksheet
+    return workbook, buffer
+
+
+class TestXlsxNoneSafety(unittest.TestCase):
+    """A None in one column must not silently drop the rest of the row.
+
+    The typed writers raise on None (len(None) / isnan(None)). Rows are written
+    column by column inside one try/except, so an unguarded None used to abort the
+    row partway through -- the columns already written stayed, everything after was
+    lost, and the result looked like a complete row. None is legitimate in the data:
+    Firefox stores NULL in moz_places.title, and items read from flat JSON (DNR
+    rules.json) have no LevelDB seq/offset.
+    """
+
+    def test_stock_xlsxwriter_still_raises_on_none(self):
+        # Guards the premise: if xlsxwriter ever starts accepting None on its own,
+        # this test fails and the workaround can be reconsidered.
+        buffer = io.BytesIO()
+        workbook = xlsxwriter.Workbook(buffer, {'in_memory': True})
+        worksheet = workbook.add_worksheet('stock')
+
+        with self.assertRaises(TypeError):
+            worksheet.write_string(0, 0, None)
+        with self.assertRaises(TypeError):
+            worksheet.write_number(0, 1, None)
+
+        workbook.close()
+
+    def test_none_does_not_truncate_the_rest_of_the_row(self):
+        workbook, buffer = _build_workbook()
+        cell_format = workbook.add_format({'font_color': 'blue'})
+        worksheet = workbook.add_worksheet('Timeline')
+
+        # A Firefox history row whose title is NULL in moz_places.
+        worksheet.write_string(0, 0, 'url', cell_format)
+        worksheet.write_string(0, 2, 'http://example.com/', cell_format)
+        worksheet.write_string(0, 3, None, cell_format)  # the NULL title
+        worksheet.write(0, 6, r'P:\profile', cell_format)
+        worksheet.write(0, 13, 18, cell_format)
+        worksheet.write_string(0, 16, 'Redirect (temporary)', cell_format)
+
+        # A DNR rules.json row, which has no LevelDB sequence number.
+        worksheet.write_string(1, 0, 'dnr extension rules', cell_format)
+        worksheet.write_number(1, 9, None, cell_format)  # the absent seq
+        worksheet.write_string(1, 10, 'Live', cell_format)
+
+        workbook.close()
+
+        rows = list(openpyxl.load_workbook(io.BytesIO(buffer.getvalue())).active.iter_rows(values_only=True))
+
+        # The None renders as an empty cell rather than a fabricated '' or 0 ...
+        self.assertIsNone(rows[0][3])
+        self.assertIsNone(rows[1][9])
+
+        # ... and every column after it still reaches the sheet.
+        self.assertEqual(rows[0][6], r'P:\profile')
+        self.assertEqual(rows[0][13], 18)
+        self.assertEqual(rows[0][16], 'Redirect (temporary)')
+        self.assertEqual(rows[1][10], 'Live')
+
+    def test_a1_notation_still_works(self):
+        # The overrides keep the base class's @convert_cell_args behaviour.
+        workbook, buffer = _build_workbook()
+        worksheet = workbook.add_worksheet('a1')
+
+        worksheet.write_string('A1', 'text')
+        worksheet.write_number('B1', 42)
+
+        workbook.close()
+
+        rows = list(openpyxl.load_workbook(io.BytesIO(buffer.getvalue())).active.iter_rows(values_only=True))
+        self.assertEqual(rows[0][0], 'text')
+        self.assertEqual(rows[0][1], 42)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Introduce `NoneSafeWorksheet` for rendering `None` as empty cells, preventing silent truncation of rows in XLSX output.
- Add tests to validate `NoneSafeWorksheet` behavior with Firefox/extension edge cases.
- Improve error logging for unexpected exceptions during data processing and cleanup actions.
- Ensure sensitive data (e.g., API keys) is redacted from logged configuration details.
- Enhance workbook generation with better handling for complex data types (e.g., lists, dicts).