### PR TITLE
Add artifact filtering and test coverage for selectable browser artif…

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,41 @@ Command Line Options:
 | -l or --log	 | Location Hindsight should log to (will append if exists) |
 | -h or --help   | Shows these options and the default Chrome data locations |
 | -t or --timezone | Display timezone for the timestamps in XLSX output |
+| --only or --artifacts | Only parse these artifacts (comma-separated; repeatable) |
+| --skip or --exclude | Parse everything except these artifacts (comma-separated; repeatable) |
+| --list-artifacts | Print the artifact names accepted by `--only` and `--skip`, then exit |
+
+## Selecting Which Artifacts to Parse
+
+By default, Hindsight parses every artifact it finds. `--only` and `--skip` narrow that
+down, which is useful for quick triage and for skipping the cache when it is large and
+not relevant to the question at hand.
+
+```
+hindsight.py -i <profile> --only history,downloads
+hindsight.py -i <profile> --skip cache
+hindsight.py -i <profile> --only user-activity --skip sessions
+```
+
+Artifact names are browser-neutral: `history` selects Chrome's `History` URL records and
+Firefox's `places.sqlite` URL records, so the same command works on either. Names are
+case-insensitive, and spaces, underscores, and hyphens are interchangeable
+(`local-storage`, `local_storage`, and `"Local Storage"` are the same name).
+
+Group names can be used anywhere an artifact name can, and select everything under them:
+`user-activity`, `website-storage`, `browser-extensions`, `configuration`, plus `caches`
+(every cache artifact) and `all`. `--only` and `--skip` can be combined, with `--skip`
+further narrowing `--only`.
+
+Run `hindsight.py --list-artifacts` for the full list with descriptions and aliases.
+
+An artifact excluded by a filter is reported as `[ skipped ]` during the run and noted in
+the log, so a report that omits an artifact stays distinguishable from a profile that
+never had it. An unrecognized name is an error rather than being ignored, so a typo can't
+quietly produce a report covering the wrong artifacts.
+
+Note that version detection still reads the profile's database schemas, so filtering does
+not change the detected browser version.
 
 ## Default Profile Paths
 

--- a/hindsight.py
+++ b/hindsight.py
@@ -20,6 +20,7 @@ import time
 import pyhindsight
 import pyhindsight.plugins
 from pyhindsight.analysis import AnalysisSession
+from pyhindsight.artifact_filter import ArtifactFilter, UnknownArtifactError, format_catalog
 from pyhindsight.utils import get_rich_banner
 
 import rich.align
@@ -94,12 +95,35 @@ The Chrome Profile folder default locations are:
                         help='Path to the cache directory; only needed if the directory is outside the given "input" '
                              'directory. Mac systems are set up this way by default. On a Mac, the default cache '
                              'directory location for Chrome is <userdir>/Library/Caches/Google/Chrome/Default/Cache/')
+    parser.add_argument('--only', '--artifacts', action='append', metavar='ARTIFACTS',
+                        help='Only parse these artifacts (comma-separated; repeatable). Accepts artifact '
+                             'names and group names, for example "--only history,downloads" or '
+                             '"--only user-activity". Use --list-artifacts to see every name.')
+    parser.add_argument('--skip', '--exclude', action='append', metavar='ARTIFACTS',
+                        help='Parse everything except these artifacts (comma-separated; repeatable), for '
+                             'example "--skip cache". Can be combined with --only, which it further narrows.')
+    parser.add_argument('--list-artifacts', '--list_artifacts', action='store_true',
+                        help='Print the artifact names accepted by --only and --skip, then exit.')
     parser.add_argument('--nocopy', '--no_copy', help='Don\'t copy files before opening them; this might run faster, '
                                                       'but some locked files may be inaccessible', action='store_true')
     parser.add_argument('--temp_dir', default=os.path.join(get_base_dir(), 'hindsight-temp'),
                         help='If files are copied before being opened, use this directory as the copy destination')
 
+    # --list-artifacts is informational and shouldn't require -i, so handle it before
+    # argparse enforces the required arguments.
+    if '--list-artifacts' in sys.argv or '--list_artifacts' in sys.argv:
+        print(format_catalog())
+        sys.exit(0)
+
     args = parser.parse_args()
+
+    # Resolve --only/--skip into the filter the run will consult. An unrecognized name
+    # is fatal rather than ignored: silently dropping a mistyped '--only' term would
+    # produce a confident-looking report covering the wrong artifacts.
+    try:
+        args.artifact_filter = ArtifactFilter.from_selectors(args.only, args.skip)
+    except UnknownArtifactError as e:
+        parser.error(str(e))
 
     # Convert any relative paths to absolute using base directory
     base_dir = get_base_dir()
@@ -194,6 +218,7 @@ def main():
         analysis_session.cache_path = args.cache
 
     analysis_session.selected_output_format = args.format
+    analysis_session.artifact_filter = args.artifact_filter
     analysis_session.browser_type = args.browser_type
     analysis_session.timezone = args.timezone
     analysis_session.no_copy = args.nocopy
@@ -229,6 +254,8 @@ def main():
     meta_table.add_row("Start time", start_time)
     meta_table.add_row("Input directory", args.input)
     meta_table.add_row("Profiles found", str(profile_count))
+    if analysis_session.artifact_filter.is_active:
+        meta_table.add_row("Artifacts", analysis_session.artifact_filter.describe())
     if args.browser_type:
         meta_table.add_row("Browser type", f"{args.browser_type} (forced via -b)")
     else:

--- a/hindsight_gui.py
+++ b/hindsight_gui.py
@@ -207,6 +207,9 @@ def display_results():
     return bottle.template('templates/results.tpl', {
         'js_installed': os.path.exists(
             os.path.join(STATIC_PATH, 'web_modules/sqlite-view.js')),
+        # A method, so it isn't in __dict__; the artifacts table needs it to show
+        # "failed" instead of a count of 0 for an artifact that couldn't be parsed.
+        'artifact_status_summary': analysis_session.artifact_status_summary(),
         **analysis_session.__dict__
         })
 

--- a/pyhindsight/analysis.py
+++ b/pyhindsight/analysis.py
@@ -12,6 +12,7 @@ import xlsxwriter.worksheet
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from pyhindsight import __version__
+from pyhindsight.artifact_filter import ArtifactFilter
 from pyhindsight.browsers.chrome import Chrome
 from pyhindsight.browsers.brave import Brave
 from pyhindsight.browsers.firefox import Firefox
@@ -472,7 +473,7 @@ class AnalysisSession(object):
             timezone=None, available_output_formats=None, selected_output_format=None, available_decrypts=None,
             selected_decrypts=None, parsed_artifacts=None, artifacts_display=None, artifacts_counts=None,
             parsed_storage=None, parsed_sync_data=None, plugin_descriptions=None, selected_plugins=None, plugin_results=None,
-            hindsight_version=None, preferences=None, originator_guids=None):
+            hindsight_version=None, preferences=None, originator_guids=None, artifact_filter=None):
         self.input_path = input_path
         self.profile_paths = profile_paths
         self.cache_path = cache_path
@@ -492,6 +493,15 @@ class AnalysisSession(object):
         self.parsed_artifacts = parsed_artifacts
         self.artifacts_display = artifacts_display
         self.artifacts_counts = artifacts_counts
+        # {profile_path: {count_key: status}} for artifacts that produced an outcome
+        # rather than a count (a failed or skipped parse). Kept separate from
+        # artifacts_counts so a count is always a count.
+        self.artifacts_status = {}
+        # Which artifacts this run is allowed to parse. A permissive filter by default,
+        # so nothing changes for callers that don't set one. The same object is shared
+        # by every profile's browser object, so its record of what was skipped covers
+        # the whole run.
+        self.artifact_filter = artifact_filter or ArtifactFilter()
         self.parsed_storage = parsed_storage
         self.parsed_extension_data = []
         self.parsed_sync_data = parsed_sync_data
@@ -603,28 +613,70 @@ class AnalysisSession(object):
 
     @staticmethod
     def sum_dict_counts(dict1, dict2):
-        """Combine two dicts by summing the values of shared keys"""
+        """Combine two dicts of record counts by summing the values of shared keys.
+
+        Both dicts hold counts only. Non-count outcomes (a failed or skipped parse) live
+        in `artifacts_status` and are removed from the counts by
+        `WebBrowser.finalize_artifact_status()` before aggregation, so there is nothing
+        to special-case here.
+
+        This used to accept a ``'Failed'`` sentinel and resolve it by substituting ``0``,
+        which reported a failed parse as "found nothing" -- and, when another profile had
+        parsed the same artifact, dropped the failure entirely. A non-numeric value now
+        means a caller bypassed finalization, which is a bug worth surfacing rather than
+        papering over with a zero.
+        """
         for key, value in list(dict2.items()):
-            # Case 1: dict2's value for key is a string (aka: it failed)
             if isinstance(value, str):
-                #  The value should only be non-int if it's a Failed message
-                if not value.startswith('Fail'):
-                    raise ValueError('Unexpected status value')
-
-                dict1[key] = dict1.setdefault(key, 0)
-
-            # Case 2: dict1's value of key is a string (aka: it failed)
-            elif isinstance(dict1.get(key), str):
-                #  The value should only be non-int if it's a Failed message
-                if not dict1.get(key).startswith('Fail'):
-                    raise ValueError('Unexpected status value')
-
-                dict1[key] = value
-
-            # Case 3: dict2's value for key is an int, or doesn't exist.
-            else:
-                dict1[key] = dict1.setdefault(key, 0) + value
+                raise TypeError(
+                    f"artifacts_counts['{key}'] is the string {value!r}; counts must be "
+                    f"numeric. Status values belong in artifacts_status -- call "
+                    f"finalize_artifact_status() on the browser before aggregating.")
+            dict1[key] = dict1.setdefault(key, 0) + value
         return dict1
+
+    def record_artifact_status(self, profile_path, browser_analysis):
+        """Record one profile's non-count artifact outcomes (failed / skipped).
+
+        Kept per profile: summing counts across profiles is fine, but "the Cookies DB
+        failed" is only meaningful attached to the profile it failed in.
+        """
+        statuses = getattr(browser_analysis, 'artifacts_status', None)
+        if statuses:
+            self.artifacts_status.setdefault(profile_path, {}).update(statuses)
+            for count_key, status in sorted(statuses.items()):
+                log.info(f' - {count_key}: {status} ({profile_path})')
+
+    def artifact_status_summary(self):
+        """Flatten per-profile statuses to {count_key: {status: [profile, ...]}}.
+
+        For output that presents one combined view of a multi-profile run. Per-profile
+        detail stays in `self.artifacts_status`; this only makes the combined view able
+        to say "failed", and in how many profiles, instead of showing a bare count.
+        """
+        summary = {}
+        for profile_path, statuses in self.artifacts_status.items():
+            for count_key, status in statuses.items():
+                summary.setdefault(count_key, {}).setdefault(status, []).append(profile_path)
+        return summary
+
+    def describe_artifact_status(self, count_key):
+        """One-line status for `count_key` across the run, or None if it has none.
+
+        Names the profile count when only some profiles were affected, because a
+        partial failure reads very differently from a total one.
+        """
+        statuses = self.artifact_status_summary().get(count_key)
+        if not statuses:
+            return None
+        total_profiles = len(self.profile_paths or []) or 1
+        parts = []
+        for status, profiles in sorted(statuses.items()):
+            if total_profiles > 1:
+                parts.append(f'{status} in {len(profiles)} of {total_profiles} profiles')
+            else:
+                parts.append(status)
+        return '; '.join(parts)
 
     def promote_object_to_analysis_session(self, item_name, item_value):
         if self.__dict__.get(item_name):
@@ -863,6 +915,8 @@ class AnalysisSession(object):
 
         # Analysis start time
         log.info("Starting analysis")
+        if self.artifact_filter.is_active:
+            log.info(f'Artifact selection in effect -- {self.artifact_filter.describe()}')
 
         log.info(f'Reading files from {self.input_path}')
         try:
@@ -900,13 +954,15 @@ class AnalysisSession(object):
                                           available_decrypts=self.available_decrypts,
                                           cache_path=self.cache_path, timezone=self.timezone,
                                           no_copy=self.no_copy, temp_dir=self.temp_dir,
-                                          originator_guids=self.originator_guids)
+                                          originator_guids=self.originator_guids,
+                                          artifact_filter=self.artifact_filter)
                 browser_analysis.process(api_keys=self.api_keys)
                 self.parsed_artifacts.extend(browser_analysis.parsed_artifacts)
                 self.parsed_storage.extend(browser_analysis.parsed_storage)
                 self.parsed_extension_data.extend(browser_analysis.parsed_extension_data)
                 self.parsed_sync_data.extend(browser_analysis.parsed_sync_data)
                 self.artifacts_counts = self.sum_dict_counts(self.artifacts_counts, browser_analysis.artifacts_counts)
+                self.record_artifact_status(found_profile_path, browser_analysis)
                 if self.artifacts_display is None:
                     self.artifacts_display = {}
                 self.artifacts_display.update(browser_analysis.artifacts_display)
@@ -945,11 +1001,13 @@ class AnalysisSession(object):
                 browser_analysis = Firefox(found_profile_path, browser_name=profile_browser_type,
                                            cache_path=self.cache_path,
                                            timezone=self.timezone,
-                                           no_copy=self.no_copy, temp_dir=self.temp_dir)
+                                           no_copy=self.no_copy, temp_dir=self.temp_dir,
+                                           artifact_filter=self.artifact_filter)
                 browser_analysis.process()
                 self.parsed_artifacts.extend(browser_analysis.parsed_artifacts)
                 self.parsed_storage.extend(browser_analysis.parsed_storage)
                 self.artifacts_counts = self.sum_dict_counts(self.artifacts_counts, browser_analysis.artifacts_counts)
+                self.record_artifact_status(found_profile_path, browser_analysis)
                 if self.artifacts_display is None:
                     self.artifacts_display = {}
                 self.artifacts_display.update(browser_analysis.artifacts_display)
@@ -979,6 +1037,7 @@ class AnalysisSession(object):
                 self.parsed_artifacts = browser_analysis.parsed_artifacts
                 self.parsed_storage.extend(browser_analysis.parsed_storage)
                 self.artifacts_counts = browser_analysis.artifacts_counts
+                self.record_artifact_status(found_profile_path, browser_analysis)
                 self.artifacts_display = browser_analysis.artifacts_display
                 self.version = browser_analysis.version
                 self.display_version = browser_analysis.display_version

--- a/pyhindsight/artifact_filter.py
+++ b/pyhindsight/artifact_filter.py
@@ -1,0 +1,335 @@
+"""Selection of which artifacts Hindsight parses.
+
+Hindsight normally parses every artifact it finds in a profile. Some
+investigations only want a slice of that: just history and downloads for a
+quick triage, or everything except the cache when the cache is enormous and
+the question at hand doesn't involve it. This module defines the artifact
+names a user selects with ``--only`` / ``--skip`` and the filter that
+``ProcessingDisplay.run()`` consults before calling each parser.
+
+The names are deliberately browser-neutral. ``history`` selects Chrome's
+``History`` URL records and Firefox's ``places.sqlite`` URL records, so the
+same command works against either profile type without the user needing to
+know which file holds what. Group names (``user-activity``, ``caches``, ...)
+are accepted anywhere an artifact name is, and expand to their members.
+
+Anything the filter excludes is recorded rather than silently dropped: a
+report that omits the cache must be distinguishable from a profile that had
+no cache, so skipped names are surfaced in the live display, the log, and on
+the AnalysisSession.
+"""
+
+import collections
+import difflib
+import logging
+import re
+
+log = logging.getLogger(__name__)
+
+
+class UnknownArtifactError(ValueError):
+    """Raised when a user-supplied artifact selector matches nothing in the catalog."""
+
+
+ArtifactSpec = collections.namedtuple('ArtifactSpec', ['name', 'group', 'description', 'aliases'])
+
+# Group names, in the order they're displayed by --list-artifacts. These mirror the
+# group headings the browsers already use in their processing display, so what a user
+# sees on screen during a run is what they can name on the command line.
+USER_ACTIVITY = 'user-activity'
+WEBSITE_STORAGE = 'website-storage'
+BROWSER_EXTENSIONS = 'browser-extensions'
+CONFIGURATION = 'configuration'
+
+GROUP_ORDER = [USER_ACTIVITY, WEBSITE_STORAGE, BROWSER_EXTENSIONS, CONFIGURATION]
+
+# The catalog of selectable artifacts. Every driver.run() call in a browser's
+# process() passes one of these names as `artifact=`; a call with no name is always
+# parsed (see ArtifactFilter.should_parse), so forgetting to tag a new parser makes it
+# unfilterable rather than invisible.
+CATALOG = [
+    # -- User Activity --
+    ArtifactSpec('history', USER_ACTIVITY,
+                 'Visited URLs (Chrome History, Firefox places.sqlite)',
+                 ('urls', 'url', 'visits', 'visit')),
+    ArtifactSpec('downloads', USER_ACTIVITY,
+                 'Downloaded files, including Chrome shared_proto_db downloads',
+                 ('download',)),
+    ArtifactSpec('archived-history', USER_ACTIVITY,
+                 'Chrome Archived History URL records',
+                 ()),
+    ArtifactSpec('media-history', USER_ACTIVITY,
+                 'Chrome Media History playback records',
+                 ('media',)),
+    ArtifactSpec('autofill', USER_ACTIVITY,
+                 'Form values typed into pages (Chrome Web Data, Firefox formhistory)',
+                 ('form-history', 'forms')),
+    ArtifactSpec('logins', USER_ACTIVITY,
+                 'Saved credentials metadata (Chrome Login Data, Firefox logins.json)',
+                 ('login', 'login-data', 'passwords')),
+    ArtifactSpec('bookmarks', USER_ACTIVITY,
+                 'Bookmarks and bookmark folders',
+                 ('bookmark',)),
+    ArtifactSpec('bookmark-backups', USER_ACTIVITY,
+                 'Firefox bookmarkbackups snapshots',
+                 ()),
+    ArtifactSpec('sessions', USER_ACTIVITY,
+                 'Open/restored tabs (Chrome SNSS, Firefox sessionstore)',
+                 ('session', 'tabs')),
+    ArtifactSpec('favicons', USER_ACTIVITY,
+                 'Firefox favicon-derived URL records',
+                 ('favicon',)),
+
+    # -- Website Storage --
+    ArtifactSpec('cookies', WEBSITE_STORAGE,
+                 'Cookies (excludes extension cookies; see extension-cookies)',
+                 ('cookie',)),
+    ArtifactSpec('cache', WEBSITE_STORAGE,
+                 'Main HTTP cache; usually the slowest artifact to parse',
+                 ()),
+    ArtifactSpec('gpu-cache', WEBSITE_STORAGE,
+                 'Chrome GPUCache entries',
+                 ('gpucache',)),
+    ArtifactSpec('media-cache', WEBSITE_STORAGE,
+                 'Chrome Media Cache entries',
+                 ()),
+    ArtifactSpec('dawn-cache', WEBSITE_STORAGE,
+                 'Chrome DawnCache / DawnWebGPUCache / DawnGraphiteCache entries',
+                 ('dawncache',)),
+    ArtifactSpec('cache-api', WEBSITE_STORAGE,
+                 'Firefox Cache API (service worker managed) entries',
+                 ()),
+    ArtifactSpec('local-storage', WEBSITE_STORAGE,
+                 'localStorage key/value pairs',
+                 ('localstorage',)),
+    ArtifactSpec('session-storage', WEBSITE_STORAGE,
+                 'sessionStorage key/value pairs',
+                 ('sessionstorage',)),
+    ArtifactSpec('indexeddb', WEBSITE_STORAGE,
+                 'IndexedDB records',
+                 ('idb', 'indexed-db')),
+    ArtifactSpec('file-system', WEBSITE_STORAGE,
+                 'File System API entries',
+                 ('filesystem',)),
+    ArtifactSpec('notifications', WEBSITE_STORAGE,
+                 'Chrome Platform Notifications',
+                 ('platform-notifications',)),
+    ArtifactSpec('service-workers', WEBSITE_STORAGE,
+                 'Service Worker registrations',
+                 ('service-worker', 'sw')),
+
+    # -- Browser Extensions --
+    ArtifactSpec('extensions', BROWSER_EXTENSIONS,
+                 'Installed extensions and their manifests',
+                 ('extension',)),
+    ArtifactSpec('extension-settings', BROWSER_EXTENSIONS,
+                 'Extension settings from Chrome Secure Preferences',
+                 ('secure-preferences',)),
+    ArtifactSpec('extension-cookies', BROWSER_EXTENSIONS,
+                 'Chrome Extension Cookies database',
+                 ()),
+    ArtifactSpec('extension-storage', BROWSER_EXTENSIONS,
+                 'Extension State/Rules/Scripts and chrome.storage.* LevelDBs',
+                 ('extension-state', 'extension-rules', 'extension-scripts')),
+    ArtifactSpec('dnr-rules', BROWSER_EXTENSIONS,
+                 'Declarative Net Request extension rules',
+                 ('dnr', 'dnr-extension-rules')),
+
+    # -- Configuration & Supporting Data --
+    ArtifactSpec('preferences', CONFIGURATION,
+                 'Profile preferences (Chrome Preferences, Firefox prefs.js)',
+                 ('prefs', 'preference')),
+    ArtifactSpec('site-characteristics', CONFIGURATION,
+                 'Chrome Site Characteristics Database',
+                 ()),
+    ArtifactSpec('sync-data', CONFIGURATION,
+                 'Chrome Sync Data records',
+                 ('sync',)),
+    ArtifactSpec('hsts', CONFIGURATION,
+                 'HSTS / TransportSecurity records',
+                 ('transport-security',)),
+    ArtifactSpec('dips', CONFIGURATION,
+                 'Chrome DIPS (Bounce Tracking Mitigation) records and popups',
+                 ()),
+    ArtifactSpec('permissions', CONFIGURATION,
+                 'Firefox per-site permissions',
+                 ('permission',)),
+    ArtifactSpec('bounce-tracking', CONFIGURATION,
+                 'Firefox bounce-tracking protection records',
+                 ()),
+    ArtifactSpec('content-blocking', CONFIGURATION,
+                 'Firefox content-blocking (protections.sqlite) events',
+                 ()),
+]
+
+ARTIFACT_NAMES = [spec.name for spec in CATALOG]
+_SPECS_BY_NAME = {spec.name: spec for spec in CATALOG}
+
+# Extra groups that don't correspond to a display heading but that users reach for.
+# 'caches' exists because "skip the caches" is a single intent even though the caches
+# are separate artifacts; naming only 'cache' skips just the main HTTP cache.
+_EXTRA_GROUPS = {
+    'caches': ('cache', 'gpu-cache', 'media-cache', 'dawn-cache', 'cache-api'),
+    'all': tuple(ARTIFACT_NAMES),
+}
+
+
+def _build_group_members():
+    members = {group: [] for group in GROUP_ORDER}
+    for spec in CATALOG:
+        members[spec.group].append(spec.name)
+    for group, names in _EXTRA_GROUPS.items():
+        members[group] = list(names)
+    return members
+
+
+GROUP_MEMBERS = _build_group_members()
+
+
+def _normalize(token):
+    """Fold a user-supplied token to catalog form.
+
+    Users type ``Local Storage``, ``local_storage``, and ``local-storage``
+    interchangeably, and copy names straight out of the on-screen display, so
+    case and space/underscore/hyphen differences are all treated as equal.
+    """
+    return re.sub(r'[\s_]+', '-', token.strip().lower())
+
+
+def _build_selector_index():
+    """Map every accepted spelling to the canonical names it selects."""
+    index = {}
+    for spec in CATALOG:
+        index[spec.name] = (spec.name,)
+        for alias in spec.aliases:
+            index[_normalize(alias)] = (spec.name,)
+    for group, names in GROUP_MEMBERS.items():
+        index[group] = tuple(names)
+    return index
+
+
+_SELECTOR_INDEX = _build_selector_index()
+
+
+def resolve_selector(token):
+    """Resolve one user-supplied token to the set of canonical artifact names it selects.
+
+    Raises UnknownArtifactError (with close-match suggestions) rather than
+    silently ignoring a token: a typo in ``--only`` would otherwise produce an
+    empty report that looks exactly like a profile with no artifacts in it.
+    """
+    normalized = _normalize(token)
+    if not normalized:
+        raise UnknownArtifactError('Empty artifact name.')
+
+    matched = _SELECTOR_INDEX.get(normalized)
+    if matched:
+        return set(matched)
+
+    suggestions = difflib.get_close_matches(normalized, sorted(_SELECTOR_INDEX), n=3, cutoff=0.6)
+    message = f"Unknown artifact '{token}'."
+    if suggestions:
+        message += ' Did you mean: ' + ', '.join(suggestions) + '?'
+    message += ' Run with --list-artifacts to see every name.'
+    raise UnknownArtifactError(message)
+
+
+def parse_selectors(tokens):
+    """Resolve an iterable of comma-separated selector strings to canonical names.
+
+    Comma is the only separator. Whitespace can't also separate, because names
+    are accepted in the spaced form users read off the screen ("Local Storage",
+    "media history"); splitting on spaces would silently turn one such name into
+    two unrelated ones.
+    """
+    resolved = set()
+    for token in tokens or []:
+        for piece in token.split(','):
+            if piece.strip():
+                resolved |= resolve_selector(piece)
+    return resolved
+
+
+class ArtifactFilter:
+    """Decides whether a given artifact should be parsed.
+
+    ``only`` restricts parsing to the named artifacts; ``skip`` removes names from
+    whatever would otherwise be parsed. The two compose, so
+    ``--only browser-extensions --skip extension-cookies`` is meaningful.
+    """
+
+    def __init__(self, only=None, skip=None):
+        self.only = set(only) if only else None
+        self.skip = set(skip) if skip else set()
+        # Populated as the run proceeds, so output can report what was actually
+        # present-but-excluded rather than what was merely named on the command line.
+        self.skipped_artifacts = set()
+
+    @classmethod
+    def from_selectors(cls, only_tokens=None, skip_tokens=None):
+        """Build a filter from raw CLI strings, validating every token."""
+        only = None
+        if only_tokens:
+            only = parse_selectors(only_tokens)
+            if not only:
+                # e.g. `--only ,` -- tokens were given but named nothing. Treating that
+                # as "no filter" would parse everything under a flag that asked for a
+                # subset, which is the opposite of what was typed.
+                raise UnknownArtifactError(
+                    '--only was given but names no artifacts. '
+                    'Run with --list-artifacts to see every name.')
+        skip = parse_selectors(skip_tokens) if skip_tokens else set()
+        return cls(only=only, skip=skip)
+
+    @property
+    def is_active(self):
+        return self.only is not None or bool(self.skip)
+
+    def should_parse(self, artifact):
+        """Return True if `artifact` should be parsed.
+
+        An untagged call (``artifact`` is None) always parses. Failing open matters:
+        a parser that hasn't been given a catalog name should show up in the report,
+        not vanish because nobody could name it.
+        """
+        if artifact is None:
+            return True
+        if artifact in self.skip:
+            return False
+        if self.only is not None and artifact not in self.only:
+            return False
+        return True
+
+    def note_skipped(self, artifact):
+        """Record that `artifact` was present in the profile but excluded by this filter."""
+        if artifact:
+            self.skipped_artifacts.add(artifact)
+
+    def describe(self):
+        """One-line summary of the active selection, for the log and the run banner."""
+        parts = []
+        if self.only is not None:
+            parts.append('only: ' + (', '.join(sorted(self.only)) or '<none>'))
+        if self.skip:
+            parts.append('skip: ' + ', '.join(sorted(self.skip)))
+        return '; '.join(parts) if parts else 'all artifacts'
+
+
+def format_catalog():
+    """Render the catalog for --list-artifacts."""
+    lines = ['Artifact names accepted by --only and --skip:', '']
+    for group in GROUP_ORDER:
+        lines.append(f'  {group}')
+        for name in GROUP_MEMBERS[group]:
+            spec = _SPECS_BY_NAME[name]
+            lines.append(f'    {spec.name:<22}{spec.description}')
+            if spec.aliases:
+                lines.append(f'    {"":<22}  aliases: {", ".join(spec.aliases)}')
+        lines.append('')
+    lines.append('  Group names select every artifact under them, and may be used')
+    lines.append('  anywhere an artifact name can: ' + ', '.join(GROUP_ORDER))
+    lines.append('  Additional groups: ' + ', '.join(sorted(_EXTRA_GROUPS)))
+    lines.append('')
+    lines.append('  Names are case-insensitive; spaces, underscores, and hyphens are equivalent.')
+    lines.append('  Artifacts not present in a profile are simply absent, filtered or not.')
+    return '\n'.join(lines)

--- a/pyhindsight/browsers/brave.py
+++ b/pyhindsight/browsers/brave.py
@@ -144,3 +144,6 @@ class Brave(Chrome):
         self.cached_key = None
 
         self.parsed_artifacts.sort(key=timeline_sort_key)
+
+        # Split parse failures out of the record counts.
+        self.finalize_artifact_status()

--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -39,14 +39,26 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+# Chrome's secondary cache directories, as (directory, row_type, artifact selector).
+# The three Dawn caches share one 'dawn-cache' selector: they are the same class of GPU
+# artifact and are wanted (or unwanted) together. Module level so the selectors can be
+# checked against the artifact catalog by tests.
+SECONDARY_CACHE_DIRS = [
+    ('GPUCache', 'gpu', 'gpu-cache'),
+    ('Media Cache', 'media', 'media-cache'),
+    ('DawnCache', 'dawn', 'dawn-cache'),
+    ('DawnWebGPUCache', 'dawn webgpu', 'dawn-cache'),
+    ('DawnGraphiteCache', 'dawn graphite', 'dawn-cache'),
+]
+
 
 class Chrome(WebBrowser):
     def __init__(self, profile_path, browser_name=None, cache_path=None, version=None, timezone=None,
                  storage=None, available_decrypts=None, no_copy=None, temp_dir=None,
-                 originator_guids=None):
+                 originator_guids=None, artifact_filter=None):
         WebBrowser.__init__(
             self, profile_path, browser_name=browser_name, cache_path=cache_path, version=version, timezone=timezone,
-            no_copy=no_copy, temp_dir=temp_dir)
+            no_copy=no_copy, temp_dir=temp_dir, artifact_filter=artifact_filter)
         self.profile_path = profile_path
         # Honor a variant passed by the caller (e.g. "Edge", "Brave", "Vivaldi");
         # all Chromium variants currently share this parser and differ only in variant.
@@ -4789,61 +4801,71 @@ class Chrome(WebBrowser):
                 driver.run(
                     'URL', 'History', self.get_history,
                     self.profile_path, 'History', self.version, 'url',
-                    display_key='History', display_value=f'URL records')
+                    display_key='History', display_value=f'URL records',
+                    artifact='history')
 
                 driver.run(
                     'Download', 'History_downloads', self.get_downloads,
                     self.profile_path, 'History', self.version, 'download',
-                    display_key='History_downloads', display_value=f'Download records')
+                    display_key='History_downloads', display_value=f'Download records',
+                    artifact='downloads')
 
             if 'shared_proto_db' in input_listing:
                 driver.run(
                     'Downloads (shared_proto_db)', 'shared_proto_db downloads',
                     self.get_shared_proto_db_downloads, self.profile_path, 'shared_proto_db',
                     display_key='shared_proto_db downloads',
-                    display_value='shared_proto_db download records')
+                    display_value='shared_proto_db download records',
+                    artifact='downloads')
 
             if 'Archived History' in input_listing:
                 driver.run(
                     'Archived History', 'Archived History', self.get_history,
                     self.profile_path, 'Archived History', self.version, 'url (archived)',
-                    display_key='Archived History', display_value='Archived URL records')
+                    display_key='Archived History', display_value='Archived URL records',
+                    artifact='archived-history')
 
             if 'Media History' in input_listing:
                 driver.run(
                     'Media History', 'Media History', self.get_media_history,
                     self.profile_path, 'Media History', self.version, 'media (playback end)',
-                    display_key='Media History', display_value='Media History records')
+                    display_key='Media History', display_value='Media History records',
+                    artifact='media-history')
 
             if 'Web Data' in input_listing:
                 driver.run(
                     'Autofill', 'Autofill', self.get_autofill,
                     self.profile_path, 'Web Data', self.version,
-                    display_key='Autofill', display_value='Autofill records')
+                    display_key='Autofill', display_value='Autofill records',
+                    artifact='autofill')
 
             if 'Login Data' in input_listing:
                 driver.run(
                     'Login Data', 'Login Data', self.get_login_data,
                     self.profile_path, 'Login Data', self.version,
-                    display_key='Login Data', display_value='Login Data records')
+                    display_key='Login Data', display_value='Login Data records',
+                    artifact='logins')
 
             if 'Login Data For Account' in input_listing:
                 driver.run(
                     'Login Data', 'Login Data', self.get_login_data,
                     self.profile_path, 'Login Data For Account', self.version,
-                    display_key='Login Data', display_value='Login Data (Account) records')
+                    display_key='Login Data', display_value='Login Data (Account) records',
+                    artifact='logins')
 
             if 'Bookmarks' in input_listing:
                 driver.run(
                     'Bookmarks', 'Bookmarks', self.get_bookmarks,
                     self.profile_path, 'Bookmarks', self.version,
-                    display_key='Bookmarks', display_value='Bookmark records')
+                    display_key='Bookmarks', display_value='Bookmark records',
+                    artifact='bookmarks')
 
             if 'Sessions' in input_listing:
                 driver.run(
                     'Sessions', 'Sessions', self.get_sessions,
                     self.profile_path, 'Sessions',
-                    display_key='Sessions', display_value='Session (SNSS) records')
+                    display_key='Sessions', display_value='Session (SNSS) records',
+                    artifact='sessions')
 
             # Website Storage
             driver.group("Website Storage")
@@ -4851,77 +4873,87 @@ class Chrome(WebBrowser):
                 driver.run(
                     'Network Cookies', 'Cookies', self.get_cookies,
                     os.path.join(self.profile_path, 'Network'), 'Cookies', self.version,
-                    display_key='Cookies', display_value='Cookie records')
+                    display_key='Cookies', display_value='Cookie records',
+                    artifact='cookies')
 
             elif 'Cookies' in input_listing:
                 driver.run(
                     'Cookies', 'Cookies', self.get_cookies,
                     self.profile_path, 'Cookies', self.version,
-                    display_key='Cookies', display_value='Cookie records')
+                    display_key='Cookies', display_value='Cookie records',
+                    artifact='cookies')
 
             if self.cache_path is not None and self.cache_path != '':
                 c_path, c_dir = os.path.split(self.cache_path)
                 driver.run(
                     'Cache', 'Cache', self.get_cache,
                     c_path, c_dir, row_type='cache',
-                    display_key='Cache', display_value='Cache records')
+                    display_key='Cache', display_value='Cache records',
+                    artifact='cache')
 
             elif 'Cache' in input_listing:
                 if os.path.isdir(os.path.join(self.profile_path, 'Cache', 'Cache_Data')):
                     driver.run(
                         'Cache', 'Cache', self.get_cache,
                         os.path.join(self.profile_path, 'Cache'), 'Cache_Data', row_type='cache',
-                        display_key='Cache', display_value='Cache records')
+                        display_key='Cache', display_value='Cache records',
+                        artifact='cache')
                 else:
                     driver.run(
                         'Cache', 'Cache', self.get_cache,
                         self.profile_path, 'Cache', row_type='cache',
-                        display_key='Cache', display_value='Cache records')
+                        display_key='Cache', display_value='Cache records',
+                        artifact='cache')
                 
-            for cache_dir, cache_type in [('GPUCache', 'gpu'), ('Media Cache', 'media'),
-                                            ('DawnCache', 'dawn'), ('DawnWebGPUCache', 'dawn webgpu'),
-                                            ('DawnGraphiteCache', 'dawn graphite')]:
+            for cache_dir, cache_type, cache_artifact in SECONDARY_CACHE_DIRS:
                 if cache_dir in input_listing:
                     driver.run(
                         cache_dir, cache_dir, self.get_cache,
                         self.profile_path, cache_dir, row_type=f'cache ({cache_type})',
-                        display_key=cache_dir, display_value=f'{cache_dir} records')
+                        display_key=cache_dir, display_value=f'{cache_dir} records',
+                        artifact=cache_artifact)
 
             if 'Local Storage' in input_listing:
                 driver.run(
                     'Local Storage', 'Local Storage', self.get_local_storage,
                     self.profile_path, 'Local Storage',
-                    display_key='Local Storage', display_value='Local Storage records')
+                    display_key='Local Storage', display_value='Local Storage records',
+                    artifact='local-storage')
 
             if 'Session Storage' in input_listing:
                 driver.run(
                     'Session Storage', 'Session Storage', self.get_session_storage,
                     self.profile_path, 'Session Storage',
-                    display_key='Session Storage', display_value='Session Storage records')
+                    display_key='Session Storage', display_value='Session Storage records',
+                    artifact='session-storage')
 
             if 'IndexedDB' in input_listing:
                 driver.run(
                     'IndexedDB', 'IndexedDB', self.get_indexeddb,
                     self.profile_path, 'IndexedDB',
-                    display_key='IndexedDB', display_value='IndexedDB records')
+                    display_key='IndexedDB', display_value='IndexedDB records',
+                    artifact='indexeddb')
 
             if 'File System' in input_listing:
                 driver.run(
                     'File System', 'File System', self.get_file_system,
                     self.profile_path, 'File System',
-                    display_key='File System', display_value='File System items')
+                    display_key='File System', display_value='File System items',
+                    artifact='file-system')
 
             if 'Platform Notifications' in input_listing:
                 driver.run(
                     'Platform Notifications', 'Platform Notifications', self.get_platform_notifications,
                     self.profile_path, 'Platform Notifications',
-                    display_key='Platform Notifications', display_value='Platform Notification records')
+                    display_key='Platform Notifications', display_value='Platform Notification records',
+                    artifact='notifications')
 
             if 'Service Worker' in input_listing:
                 driver.run(
                     'Service Workers', 'Service Workers', self.get_service_workers,
                     self.profile_path, 'Service Worker',
-                    display_key='Service Workers', display_value='Service Worker registrations')
+                    display_key='Service Workers', display_value='Service Worker registrations',
+                    artifact='service-workers')
 
             # Browser Extensions
             driver.group("Browser Extensions")
@@ -4930,13 +4962,15 @@ class Chrome(WebBrowser):
                 driver.run(
                     'Extensions', 'Extensions', self.get_extensions,
                     self.profile_path, 'Extensions',
-                    display_key='Extensions', display_value='Installed Extensions')
+                    display_key='Extensions', display_value='Installed Extensions',
+                    artifact='extensions')
 
             if 'Secure Preferences' in input_listing:
                 driver.run(
                     'Extension Settings', 'Secure Preferences', self.get_extension_settings,
                     self.profile_path, 'Secure Preferences',
-                    display_key='Extension Settings', display_value='Extension settings entries')
+                    display_key='Extension Settings', display_value='Extension settings entries',
+                    artifact='extension-settings')
 
             if 'Extension Cookies' in input_listing:
                 # Workaround to cap the version at 65 for Extension Cookies, as until that
@@ -4950,20 +4984,23 @@ class Chrome(WebBrowser):
                 driver.run(
                     'Extension Cookies', 'Extension Cookies', self.get_cookies,
                     self.profile_path, 'Extension Cookies', ext_cookies_version,
-                    display_key='Extension Cookies', display_value='Extension Cookie records')
+                    display_key='Extension Cookies', display_value='Extension Cookie records',
+                    artifact='extension-cookies')
 
             for directory in ['Extension Rules', 'Extension Scripts', 'Extension State']:
                 if directory in input_listing:
                     driver.run(
                         directory, directory, self.get_unified_extension_data,
                         self.profile_path, directory,
-                        display_key=f'{directory}', display_value=f'{directory} records')
+                        display_key=f'{directory}', display_value=f'{directory} records',
+                        artifact='extension-storage')
 
             if 'DNR Extension Rules' in input_listing:
                 driver.run(
                     'DNR Extension Rules', 'DNR Extension Rules', self.get_dnr_extension_rules,
                     self.profile_path, 'DNR Extension Rules',
-                    display_key='DNR Extension Rules', display_value='DNR Extension Rules records')
+                    display_key='DNR Extension Rules', display_value='DNR Extension Rules records',
+                    artifact='dnr-rules')
 
             for directory in ['Local App Settings', 'Local Extension Settings',
                               'Managed Extension Settings', 'Sync App Settings', 'Sync Extension Settings']:
@@ -4971,7 +5008,8 @@ class Chrome(WebBrowser):
                     driver.run(
                         directory, directory, self.get_partitioned_extension_data,
                         self.profile_path, directory,
-                        display_key=f'{directory}', display_value=f'{directory} records')
+                        display_key=f'{directory}', display_value=f'{directory} records',
+                        artifact='extension-storage')
 
             # Configuration & Supporting Data
             driver.group("Configuration & Supporting Data")
@@ -4980,42 +5018,49 @@ class Chrome(WebBrowser):
                 driver.run(
                     'Preferences', 'Preferences', self.get_preferences,
                     self.profile_path, 'Preferences',
-                    display_key='Preferences', display_value='Preference items')
+                    display_key='Preferences', display_value='Preference items',
+                    artifact='preferences')
 
             if 'Site Characteristics Database' in input_listing:
                 driver.run(
                     'Site Characteristics', 'Site Characteristics', self.get_site_characteristics,
                     self.profile_path, 'Site Characteristics Database',
-                    display_key='Site Characteristics', display_value='Site Characteristics records')
+                    display_key='Site Characteristics', display_value='Site Characteristics records',
+                    artifact='site-characteristics')
 
             if 'Sync Data' in input_listing:
                 driver.run(
                     'Sync Data', 'Sync Data', self.get_sync_data,
                     self.profile_path, 'Sync Data',
-                    display_key='Sync Data', display_value='Sync Data records')
+                    display_key='Sync Data', display_value='Sync Data records',
+                    artifact='sync-data')
 
             if network_listing and 'TransportSecurity' in network_listing:
                 driver.run(
                     'Network HSTS', 'HSTS', self.get_transport_security,
                     os.path.join(self.profile_path, 'Network'), 'TransportSecurity',
-                    display_key='HSTS', display_value='HSTS records')
+                    display_key='HSTS', display_value='HSTS records',
+                    artifact='hsts')
 
             elif 'TransportSecurity' in input_listing:
                 driver.run(
                     'HSTS', 'HSTS', self.get_transport_security,
                     self.profile_path, 'TransportSecurity',
-                    display_key='HSTS', display_value='HSTS records')
+                    display_key='HSTS', display_value='HSTS records',
+                    artifact='hsts')
 
             if 'DIPS' in input_listing:
                 driver.run(
                     'DIPS Popups', 'DIPS Popups', self.get_dips_popups,
                     self.profile_path, 'DIPS', self.version,
-                    display_key='DIPS Popups', display_value='DIPS Popup records')
+                    display_key='DIPS Popups', display_value='DIPS Popup records',
+                    artifact='dips')
 
                 driver.run(
                     'DIPS', 'DIPS', self.get_dips,
                     self.profile_path, 'DIPS', self.version,
-                    display_key='DIPS', display_value='DIPS records')
+                    display_key='DIPS', display_value='DIPS records',
+                    artifact='dips')
 
         # Destroy the cached key so that JSON serialization doesn't
         # have a cardiac arrest on the non-unicode binary data.
@@ -5048,6 +5093,10 @@ class Chrome(WebBrowser):
 
         self.parsed_artifacts.sort(key=timeline_sort_key)
         self.parsed_storage.sort()
+
+        # Split parse failures out of the record counts now that the live display has
+        # finished reading them.
+        self.finalize_artifact_status()
 
         # Clean temp directory after processing profile
         if not self.no_copy:

--- a/pyhindsight/browsers/firefox.py
+++ b/pyhindsight/browsers/firefox.py
@@ -130,10 +130,10 @@ INTERESTING_PREFS = [
 
 class Firefox(WebBrowser):
     def __init__(self, profile_path, browser_name=None, cache_path=None, version=None, timezone=None,
-                 no_copy=None, temp_dir=None):
+                 no_copy=None, temp_dir=None, artifact_filter=None):
         WebBrowser.__init__(
             self, profile_path, browser_name=browser_name, cache_path=cache_path, version=version,
-            timezone=timezone, no_copy=no_copy, temp_dir=temp_dir)
+            timezone=timezone, no_copy=no_copy, temp_dir=temp_dir, artifact_filter=artifact_filter)
         self.profile_path = profile_path
         # Honor a variant passed by the caller (e.g. "Tor"); Tor Browser is
         # Firefox-based and currently shares this parser, differing only in variant.
@@ -2955,41 +2955,48 @@ class Firefox(WebBrowser):
                 driver.run(
                     'URL records', 'places.sqlite', self.get_history,
                     self.profile_path, 'places.sqlite',
-                    display_key='places.sqlite', display_value='URL records')
+                    display_key='places.sqlite', display_value='URL records',
+                    artifact='history')
 
                 driver.run(
                     'Download records', 'places.sqlite_downloads', self.get_downloads,
                     self.profile_path, 'places.sqlite',
-                    display_key='places.sqlite_downloads', display_value='Download records')
+                    display_key='places.sqlite_downloads', display_value='Download records',
+                    artifact='downloads')
 
                 driver.run(
                     'Bookmark records', 'Bookmarks', self.get_bookmarks,
                     self.profile_path, 'places.sqlite',
-                    display_key='Bookmarks', display_value='Bookmark records')
+                    display_key='Bookmarks', display_value='Bookmark records',
+                    artifact='bookmarks')
 
             if 'formhistory.sqlite' in input_listing:
                 driver.run(
                     'Form history records', 'formhistory.sqlite', self.get_form_history,
                     self.profile_path, 'formhistory.sqlite',
-                    display_key='formhistory.sqlite', display_value='Form history records')
+                    display_key='formhistory.sqlite', display_value='Form history records',
+                    artifact='autofill')
 
             if 'sessionstore.jsonlz4' in input_listing or 'sessionstore-backups' in input_listing:
                 driver.run(
                     'Session (tab) records', 'Sessions', self.get_sessionstore,
                     self.profile_path,
-                    display_key='Sessions', display_value='Session (tab) records')
+                    display_key='Sessions', display_value='Session (tab) records',
+                    artifact='sessions')
 
             if 'bookmarkbackups' in input_listing:
                 driver.run(
                     'Bookmark backup records', 'Bookmark Backups', self.get_bookmark_backups,
                     self.profile_path,
-                    display_key='Bookmark Backups', display_value='Bookmark backup records')
+                    display_key='Bookmark Backups', display_value='Bookmark backup records',
+                    artifact='bookmark-backups')
 
             if 'favicons.sqlite' in input_listing:
                 driver.run(
                     'Favicon-derived URL records', 'Favicons', self.get_favicons,
                     self.profile_path, 'favicons.sqlite',
-                    display_key='Favicons', display_value='Favicon-derived URL records')
+                    display_key='Favicons', display_value='Favicon-derived URL records',
+                    artifact='favicons')
 
             # Website Storage
             driver.group("Website Storage")
@@ -2997,31 +3004,36 @@ class Firefox(WebBrowser):
                 driver.run(
                     'Cookie records', 'Cookies', self.get_cookies,
                     self.profile_path, 'cookies.sqlite',
-                    display_key='Cookies', display_value='Cookie records')
+                    display_key='Cookies', display_value='Cookie records',
+                    artifact='cookies')
 
             if 'storage' in input_listing and os.path.isdir(
                     os.path.join(self.profile_path, 'storage', 'default')):
                 driver.run(
                     'Local Storage records', 'Local Storage', self.get_local_storage,
                     self.profile_path,
-                    display_key='Local Storage', display_value='Local Storage records')
+                    display_key='Local Storage', display_value='Local Storage records',
+                    artifact='local-storage')
 
                 driver.run(
                     'IndexedDB records', 'IndexedDB', self.get_indexeddb,
                     self.profile_path,
-                    display_key='IndexedDB', display_value='IndexedDB records')
+                    display_key='IndexedDB', display_value='IndexedDB records',
+                    artifact='indexeddb')
 
                 driver.run(
                     'Cache API records', 'Cache API', self.get_cache_storage,
                     self.profile_path,
-                    display_key='Cache API', display_value='Cache API records')
+                    display_key='Cache API', display_value='Cache API records',
+                    artifact='cache-api')
 
             cache_dir = self._resolve_cache_dir()
             if cache_dir:
                 driver.run(
                     'Cache records', 'Cache', self.get_cache,
                     cache_dir,
-                    display_key='Cache', display_value='Cache records')
+                    display_key='Cache', display_value='Cache records',
+                    artifact='cache')
             else:
                 log.info('No Firefox cache2 directory found; skipping cache parse.')
 
@@ -3031,7 +3043,8 @@ class Firefox(WebBrowser):
                 driver.run(
                     'Installed Extensions', 'Extensions', self.get_extensions,
                     self.profile_path, 'extensions.json',
-                    display_key='Extensions', display_value='Installed Extensions')
+                    display_key='Extensions', display_value='Installed Extensions',
+                    artifact='extensions')
 
             # Configuration & Supporting Data
             driver.group("Configuration & Supporting Data")
@@ -3039,39 +3052,49 @@ class Firefox(WebBrowser):
                 driver.run(
                     'Preference items', 'Preferences', self.get_preferences,
                     self.profile_path, 'prefs.js',
-                    display_key='Preferences', display_value='Preference items')
+                    display_key='Preferences', display_value='Preference items',
+                    artifact='preferences')
 
             if 'permissions.sqlite' in input_listing:
                 driver.run(
                     'Permission records', 'Permissions', self.get_permissions,
                     self.profile_path, 'permissions.sqlite',
-                    display_key='Permissions', display_value='Permission records')
+                    display_key='Permissions', display_value='Permission records',
+                    artifact='permissions')
 
             if 'SiteSecurityServiceState.bin' in input_listing:
                 driver.run(
                     'HSTS records', 'HSTS', self.get_hsts,
                     self.profile_path, 'SiteSecurityServiceState.bin',
-                    display_key='HSTS', display_value='HSTS records')
+                    display_key='HSTS', display_value='HSTS records',
+                    artifact='hsts')
 
             if 'logins.json' in input_listing:
                 driver.run(
                     'Saved login records', 'Logins', self.get_logins,
                     self.profile_path, 'logins.json',
-                    display_key='Logins', display_value='Saved login records')
+                    display_key='Logins', display_value='Saved login records',
+                    artifact='logins')
 
             if 'bounce-tracking-protection.sqlite' in input_listing:
                 driver.run(
                     'Bounce-tracking records', 'Bounce Tracking', self.get_bounce_tracking,
                     self.profile_path, 'bounce-tracking-protection.sqlite',
-                    display_key='Bounce Tracking', display_value='Bounce-tracking records')
+                    display_key='Bounce Tracking', display_value='Bounce-tracking records',
+                    artifact='bounce-tracking')
 
             if 'protections.sqlite' in input_listing:
                 driver.run(
                     'Content-blocking event records', 'Content Blocking', self.get_content_blocking,
                     self.profile_path, 'protections.sqlite',
-                    display_key='Content Blocking', display_value='Content-blocking event records')
+                    display_key='Content Blocking', display_value='Content-blocking event records',
+                    artifact='content-blocking')
 
         self.parsed_artifacts.sort(key=timeline_sort_key)
+
+        # Split parse failures out of the record counts now that the live display has
+        # finished reading them.
+        self.finalize_artifact_status()
 
     class URLItem(WebBrowser.URLItem):
         pass

--- a/pyhindsight/browsers/webbrowser.py
+++ b/pyhindsight/browsers/webbrowser.py
@@ -14,8 +14,15 @@ import rich.spinner
 import rich.table
 import rich.text
 from pyhindsight import utils
+from pyhindsight.artifact_filter import ArtifactFilter
 
 log = logging.getLogger(__name__)
+
+# Per-artifact outcomes that are not record counts. These live in `artifacts_status`
+# rather than `artifacts_counts` so that a count is always a count: "couldn't read this"
+# and "read it, found nothing" have to stay distinguishable in output.
+ARTIFACT_STATUS_FAILED = 'failed'
+ARTIFACT_STATUS_SKIPPED = 'skipped'
 
 # Sorts before any real timestamp; only ever used to order un-timestamped items among
 # themselves, never rendered.
@@ -80,10 +87,33 @@ class ProcessingDisplay:
         """Set the group subsequent run() calls are bucketed under."""
         self.current_group = name
 
-    def run(self, label, count_key, func, *args, display_key=None, display_value=None, **kwargs):
-        """Show a spinner row, run the parser, then replace it with its count."""
+    def run(self, label, count_key, func, *args, display_key=None, display_value=None,
+            artifact=None, **kwargs):
+        """Show a spinner row, run the parser, then replace it with its count.
+
+        ``artifact`` is the catalog name from ``pyhindsight.artifact_filter`` that
+        ``--only`` / ``--skip`` select on. When the run's filter excludes it, the
+        parser is not called and the row reads "skipped" instead of a count, so a
+        filtered-out artifact never reads as an artifact that wasn't there.
+        """
         group_rows = self.output_groups.setdefault(self.current_group, [])
         display_label = display_value or self.browser.artifacts_display.get(display_key, label)
+
+        artifact_filter = self.browser.artifact_filter
+        if artifact_filter and not artifact_filter.should_parse(artifact):
+            artifact_filter.note_skipped(artifact)
+            self.browser.artifacts_status[count_key] = ARTIFACT_STATUS_SKIPPED
+            log.info(f' - Skipping {label} ({artifact}); excluded by artifact filter')
+            # Neither artifacts_counts nor artifacts_display is written for a skipped
+            # artifact. Absent from artifacts_counts means "not parsed", which has to
+            # stay distinguishable from a count of zero -- and consumers that iterate
+            # artifacts_display key off it while defaulting the count to 0
+            # (parsed_artifacts.tpl does exactly that), so recording the label alone
+            # would render the artifact as "0" rather than omitting it.
+            group_rows.append((display_label, self._bracketed_count('skipped')))
+            self._live.update(self._build_live_view())
+            return
+
         group_rows.append((display_label, self._bracketed_spinner()))
         self._live.update(self._build_live_view())
         func(*args, **kwargs)
@@ -146,6 +176,8 @@ class ProcessingDisplay:
         text.append("[ ", style="dim")
         if str(count) == "Failed":
             text.append(f"{count:>{self.count_width}}", style="red")
+        elif str(count) == "skipped":
+            text.append(f"{count:>{self.count_width}}", style="yellow")
         elif str(count) == "0":
             text.append(f"{count:>{self.count_width}}", style="dim")
         else:
@@ -157,7 +189,10 @@ class ProcessingDisplay:
 class WebBrowser(object):
     def __init__(
             self, profile_path, browser_name, cache_path=None, version=None, display_version=None,
-            timezone=None, structure=None, no_copy=None, temp_dir=None):
+            timezone=None, structure=None, no_copy=None, temp_dir=None, artifact_filter=None):
+        # A permissive filter by default, so a browser constructed directly (tests,
+        # library use) parses everything without the caller having to supply one.
+        self.artifact_filter = artifact_filter or ArtifactFilter()
         self.profile_path = profile_path
         self.browser_name = browser_name
         self.cache_path = cache_path
@@ -171,6 +206,9 @@ class WebBrowser(object):
         self.parsed_sync_data = []
         self.artifacts_counts = {}
         self.artifacts_display = {}
+        # {count_key: status}, for artifacts that produced an outcome rather than a
+        # count. See finalize_artifact_status().
+        self.artifacts_status = {}
         self.preferences = []
         self.no_copy = no_copy
         self.temp_dir = temp_dir
@@ -179,6 +217,30 @@ class WebBrowser(object):
 
         if self.version is None:
             self.version = []
+
+    def finalize_artifact_status(self):
+        """Move sentinel status strings out of `artifacts_counts` into `artifacts_status`.
+
+        Parsers signal a failed parse by writing the string ``'Failed'`` into
+        `artifacts_counts` -- the same dict that holds record counts. Mixing the two
+        forces every consumer to special-case strings, and the aggregation in
+        AnalysisSession used to resolve them by substituting ``0``, silently turning
+        "couldn't read this artifact" into "read it and found nothing". Those are
+        opposite findings, so the status is moved somewhere it can't be mistaken for a
+        count, and the key is removed from `artifacts_counts` entirely: absent means
+        "no count was produced", which stays distinguishable from a count of zero.
+
+        Called at the end of each browser's process(), after the live display has
+        finished reading counts, so the on-screen "[ Failed ]" rendering is unaffected.
+        Idempotent.
+        """
+        for count_key, value in list(self.artifacts_counts.items()):
+            if isinstance(value, str):
+                # Recorded verbatim (lowercased) rather than validated against a known
+                # set. A status nobody anticipated is still information, and dropping
+                # or rejecting it is how the old code lost failures.
+                self.artifacts_status[count_key] = value.lower()
+                del self.artifacts_counts[count_key]
 
     @staticmethod
     def format_processing_output(name, items):

--- a/pyhindsight/templates/parsed_artifacts.tpl
+++ b/pyhindsight/templates/parsed_artifacts.tpl
@@ -9,12 +9,24 @@
                 <td width=4px></td>
             </tr>
          % display_items = list(artifacts_display.keys())
+         % status_summary = artifact_status_summary if defined('artifact_status_summary') else {}
+         % def cell(key):
+         %     statuses = status_summary.get(key)
+         %     count = artifacts_counts.get(key)
+         %     if statuses and count is None:
+         %         return '/'.join(sorted(statuses))
+         %     end
+         %     if statuses:
+         %         return '{} ({})'.format(count, '/'.join(sorted(statuses)))
+         %     end
+         %     return 0 if count is None else count
+         % end
          % display_order = ['Archived History', 'History', 'History_downloads', 'Cache', 'Application Cache', 'Media Cache', 'GPUCache', 'Cookies', 'Local Storage', 'Bookmarks', 'Autofill', 'Login Data', 'Preferences', 'Extensions', 'Extension Cookies' ]
          % while len(display_order) > 0:
          %   if display_order[0] in display_items:
             <tr class="results-row">
                 <td align="right">{{artifacts_display[display_order[0]]}}:</td>
-                <td align="right">{{artifacts_counts.get(display_order[0], 0)}}</td>
+                <td align="right">{{cell(display_order[0])}}</td>
                 <td width=4px></td>
 
             </tr>
@@ -26,7 +38,7 @@
          % for artifact in display_items:
             <tr class="results-row">
                 <td align="right">{{artifacts_display[artifact]}}:</td>
-                <td align="right">{{artifacts_counts.get(artifact, 0)}}</td>
+                <td align="right">{{cell(artifact)}}</td>
                 <td width=4px></td>
             </tr>
          % end

--- a/tests/test_artifact_filter.py
+++ b/tests/test_artifact_filter.py
@@ -1,0 +1,308 @@
+import unittest
+
+from pyhindsight import artifact_filter
+from pyhindsight.artifact_filter import (
+    ArtifactFilter,
+    UnknownArtifactError,
+    format_catalog,
+    parse_selectors,
+    resolve_selector,
+)
+
+
+class TestSelectorResolution(unittest.TestCase):
+    """User-supplied artifact names resolve to canonical names, or fail loudly."""
+
+    def test_canonical_name_resolves_to_itself(self):
+        self.assertEqual({'cookies'}, resolve_selector('cookies'))
+
+    def test_alias_resolves_to_canonical_name(self):
+        # The issue's own example wording ("only visits, downloads") should just work.
+        self.assertEqual({'history'}, resolve_selector('visits'))
+        self.assertEqual({'logins'}, resolve_selector('passwords'))
+        self.assertEqual({'autofill'}, resolve_selector('form-history'))
+
+    def test_names_are_case_and_separator_insensitive(self):
+        for spelling in ('local-storage', 'local_storage', 'Local Storage', '  LOCAL STORAGE  '):
+            self.assertEqual({'local-storage'}, resolve_selector(spelling), spelling)
+
+    def test_group_expands_to_its_members(self):
+        resolved = resolve_selector('browser-extensions')
+        self.assertIn('extensions', resolved)
+        self.assertIn('extension-cookies', resolved)
+        self.assertNotIn('history', resolved)
+
+    def test_caches_group_covers_every_cache_artifact(self):
+        # "skip the caches" is one intent even though the caches are separate artifacts.
+        self.assertEqual(
+            {'cache', 'gpu-cache', 'media-cache', 'dawn-cache', 'cache-api'},
+            resolve_selector('caches'))
+
+    def test_unknown_name_raises_with_suggestions(self):
+        with self.assertRaises(UnknownArtifactError) as raised:
+            resolve_selector('histry')
+        message = str(raised.exception)
+        self.assertIn('histry', message)
+        self.assertIn('history', message)
+
+    def test_unknown_name_is_never_silently_ignored(self):
+        # A typo that resolved to "nothing" would produce an empty report that reads
+        # exactly like a profile with no artifacts in it.
+        with self.assertRaises(UnknownArtifactError):
+            parse_selectors(['history,notathing'])
+
+
+class TestSelectorParsing(unittest.TestCase):
+
+    def test_comma_separated_list(self):
+        self.assertEqual({'history', 'downloads'}, parse_selectors(['history,downloads']))
+
+    def test_repeated_flag_values_accumulate(self):
+        self.assertEqual({'history', 'cookies'}, parse_selectors(['history', 'cookies']))
+
+    def test_multi_word_names_survive_parsing(self):
+        # Splitting on whitespace as well as commas would turn "media history" into
+        # 'media' + 'history' -- two different artifacts, one of them not asked for.
+        self.assertEqual({'media-history'}, parse_selectors(['media history']))
+        self.assertEqual(
+            {'local-storage', 'session-storage'},
+            parse_selectors(['Local Storage, Session Storage']))
+
+    def test_blank_entries_are_ignored(self):
+        self.assertEqual({'history'}, parse_selectors(['history,', ' ']))
+
+
+class TestArtifactFilter(unittest.TestCase):
+
+    def test_default_filter_parses_everything(self):
+        f = ArtifactFilter()
+        self.assertFalse(f.is_active)
+        for name in artifact_filter.ARTIFACT_NAMES:
+            self.assertTrue(f.should_parse(name), name)
+
+    def test_only_restricts_to_named_artifacts(self):
+        f = ArtifactFilter.from_selectors(only_tokens=['history,downloads'])
+        self.assertTrue(f.should_parse('history'))
+        self.assertTrue(f.should_parse('downloads'))
+        self.assertFalse(f.should_parse('cache'))
+        self.assertTrue(f.is_active)
+
+    def test_skip_removes_named_artifacts(self):
+        f = ArtifactFilter.from_selectors(skip_tokens=['cache'])
+        self.assertFalse(f.should_parse('cache'))
+        self.assertTrue(f.should_parse('history'))
+        # Naming only 'cache' skips the main HTTP cache, not the GPU/Dawn caches.
+        self.assertTrue(f.should_parse('gpu-cache'))
+
+    def test_only_and_skip_compose(self):
+        f = ArtifactFilter.from_selectors(
+            only_tokens=['browser-extensions'], skip_tokens=['extension-cookies'])
+        self.assertTrue(f.should_parse('extensions'))
+        self.assertFalse(f.should_parse('extension-cookies'))
+        self.assertFalse(f.should_parse('history'))
+
+    def test_only_that_names_nothing_is_an_error(self):
+        # Falling back to "no filter" here would parse everything under a flag that
+        # explicitly asked for a subset.
+        with self.assertRaises(UnknownArtifactError):
+            ArtifactFilter.from_selectors(only_tokens=[','])
+
+    def test_untagged_artifact_always_parses(self):
+        # Failing open: a parser nobody gave a catalog name to must still show up in
+        # the report rather than vanish because it can't be named.
+        f = ArtifactFilter.from_selectors(only_tokens=['history'])
+        self.assertTrue(f.should_parse(None))
+
+    def test_skipped_artifacts_are_recorded(self):
+        f = ArtifactFilter.from_selectors(skip_tokens=['cache'])
+        f.note_skipped('cache')
+        self.assertEqual({'cache'}, f.skipped_artifacts)
+
+    def test_describe_reports_the_active_selection(self):
+        self.assertEqual('all artifacts', ArtifactFilter().describe())
+        described = ArtifactFilter.from_selectors(
+            only_tokens=['history'], skip_tokens=['cache']).describe()
+        self.assertIn('only: history', described)
+        self.assertIn('skip: cache', described)
+
+
+class TestCatalogIntegrity(unittest.TestCase):
+    """The catalog is the contract between the CLI and the parser call sites."""
+
+    def test_names_and_aliases_are_unique(self):
+        seen = {}
+        for spec in artifact_filter.CATALOG:
+            for token in (spec.name,) + spec.aliases:
+                normalized = artifact_filter._normalize(token)
+                self.assertNotIn(
+                    normalized, seen,
+                    f"'{token}' is claimed by both {seen.get(normalized)} and {spec.name}")
+                seen[normalized] = spec.name
+
+    def test_group_names_do_not_collide_with_artifact_names(self):
+        for group in artifact_filter.GROUP_MEMBERS:
+            self.assertNotIn(group, artifact_filter.ARTIFACT_NAMES, group)
+
+    def test_every_artifact_belongs_to_a_displayed_group(self):
+        for spec in artifact_filter.CATALOG:
+            self.assertIn(spec.group, artifact_filter.GROUP_ORDER, spec.name)
+
+    def test_all_group_covers_the_whole_catalog(self):
+        self.assertEqual(set(artifact_filter.ARTIFACT_NAMES), resolve_selector('all'))
+
+    def test_catalog_lists_every_artifact(self):
+        rendered = format_catalog()
+        for name in artifact_filter.ARTIFACT_NAMES:
+            self.assertIn(name, rendered, name)
+
+
+class TestParserCallSitesAreTagged(unittest.TestCase):
+    """Every parser the browsers run must be selectable, and spelled correctly.
+
+    These names are only strings at the call sites, so a typo would silently make an
+    artifact unselectable (it fails open and always parses). Checking the source keeps
+    the catalog and the call sites from drifting apart as parsers are added.
+    """
+
+    @staticmethod
+    def _artifact_names_in(module_path):
+        import re
+        with open(module_path, encoding='utf-8') as source:
+            return re.findall(r"artifact='([^']+)'", source.read())
+
+    def _assert_module_tagged(self, module):
+        import inspect
+        path = inspect.getfile(module)
+        used = self._artifact_names_in(path)
+        self.assertTrue(used, f'no tagged parser call sites found in {path}')
+        for name in used:
+            self.assertIn(name, artifact_filter.ARTIFACT_NAMES,
+                          f"'{name}' in {path} is not in the artifact catalog")
+
+    def test_chrome_call_sites_use_catalog_names(self):
+        from pyhindsight.browsers import chrome
+        self._assert_module_tagged(chrome)
+
+    def test_firefox_call_sites_use_catalog_names(self):
+        from pyhindsight.browsers import firefox
+        self._assert_module_tagged(firefox)
+
+    def test_secondary_cache_selectors_are_catalog_names(self):
+        # These are passed to driver.run() as a variable rather than a literal, so the
+        # source scan above can't see them.
+        from pyhindsight.browsers.chrome import SECONDARY_CACHE_DIRS
+        for _, _, selector in SECONDARY_CACHE_DIRS:
+            self.assertIn(selector, artifact_filter.ARTIFACT_NAMES, selector)
+
+    def test_every_driver_run_call_is_tagged(self):
+        # An untagged call site parses unconditionally, so --only/--skip would quietly
+        # have no effect on it. Catch that here rather than in an investigation.
+        import inspect
+        import re
+        from pyhindsight.browsers import chrome, firefox
+        for module in (chrome, firefox):
+            path = inspect.getfile(module)
+            with open(path, encoding='utf-8') as source:
+                text = source.read()
+            call_count = len(re.findall(r'driver\.run\(', text))
+            tagged_count = len(re.findall(r'\n\s*artifact=', text))
+            self.assertEqual(
+                call_count, tagged_count,
+                f'{path}: {call_count} driver.run() calls but {tagged_count} artifact= tags')
+
+
+class _FakeBrowser:
+    """Minimal stand-in for the browser state ProcessingDisplay reads."""
+
+    def __init__(self, artifact_filter_):
+        self.artifact_filter = artifact_filter_
+        self.artifacts_counts = {}
+        self.artifacts_display = {}
+        self.artifacts_status = {}
+        self.profile_path = 'fixture-profile'
+        self.browser_name = 'Chrome'
+        self.display_version = '999'
+
+
+class TestProcessingDisplayHonorsFilter(unittest.TestCase):
+    """The filter has to stop the parser running, not just hide its row."""
+
+    def _driver(self, artifact_filter_):
+        import io
+        import rich.console
+        from pyhindsight.browsers.webbrowser import ProcessingDisplay
+
+        driver = ProcessingDisplay(_FakeBrowser(artifact_filter_), ['Group'])
+        # Render into a buffer so the test doesn't paint the terminal.
+        driver.console = rich.console.Console(file=io.StringIO(), width=100)
+        return driver
+
+    def test_excluded_parser_is_not_called(self):
+        calls = []
+        driver = self._driver(ArtifactFilter.from_selectors(skip_tokens=['cache']))
+        with driver:
+            driver.group('Group')
+            driver.run('Cache', 'Cache', lambda: calls.append('cache'),
+                       display_key='Cache', display_value='Cache records', artifact='cache')
+        self.assertEqual([], calls)
+
+    def test_included_parser_is_called(self):
+        calls = []
+        driver = self._driver(ArtifactFilter.from_selectors(skip_tokens=['cache']))
+        with driver:
+            driver.group('Group')
+            driver.run('URL', 'History', lambda: calls.append('history'),
+                       display_key='History', display_value='URL records', artifact='history')
+        self.assertEqual(['history'], calls)
+
+    def test_excluded_artifact_writes_no_count(self):
+        # Absent from artifacts_counts means "not parsed", which has to stay
+        # distinguishable from a parsed artifact that found nothing (a count of 0).
+        driver = self._driver(ArtifactFilter.from_selectors(skip_tokens=['cache']))
+        with driver:
+            driver.group('Group')
+            driver.run('Cache', 'Cache', lambda: None,
+                       display_key='Cache', display_value='Cache records', artifact='cache')
+        self.assertNotIn('Cache', driver.browser.artifacts_counts)
+
+    def test_excluded_artifact_writes_no_display_label(self):
+        # Consumers iterate artifacts_display and default a missing count to 0
+        # (parsed_artifacts.tpl), so recording the label without a count would render
+        # a skipped artifact as "0" instead of leaving it out.
+        driver = self._driver(ArtifactFilter.from_selectors(skip_tokens=['cache']))
+        with driver:
+            driver.group('Group')
+            driver.run('Cache', 'Cache', lambda: None,
+                       display_key='Cache', display_value='Cache records', artifact='cache')
+        self.assertNotIn('Cache', driver.browser.artifacts_display)
+
+    def test_excluded_artifact_still_shows_its_label_on_screen(self):
+        # Dropping the artifacts_display write must not blank the row in the live UI.
+        driver = self._driver(ArtifactFilter.from_selectors(skip_tokens=['cache']))
+        with driver:
+            driver.group('Group')
+            driver.run('Cache', 'Cache', lambda: None,
+                       display_key='Cache', display_value='Cache records', artifact='cache')
+        label, _ = driver.output_groups['Group'][0]
+        self.assertEqual('Cache records', label)
+
+    def test_excluded_artifact_is_recorded_on_the_filter(self):
+        artifact_filter_ = ArtifactFilter.from_selectors(skip_tokens=['cache'])
+        driver = self._driver(artifact_filter_)
+        with driver:
+            driver.group('Group')
+            driver.run('Cache', 'Cache', lambda: None,
+                       display_key='Cache', display_value='Cache records', artifact='cache')
+        self.assertEqual({'cache'}, artifact_filter_.skipped_artifacts)
+
+    def test_untagged_call_runs_under_an_only_filter(self):
+        calls = []
+        driver = self._driver(ArtifactFilter.from_selectors(only_tokens=['history']))
+        with driver:
+            driver.group('Group')
+            driver.run('Mystery', 'Mystery', lambda: calls.append('mystery'))
+        self.assertEqual(['mystery'], calls)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_artifact_status.py
+++ b/tests/test_artifact_status.py
@@ -1,0 +1,127 @@
+import unittest
+
+from pyhindsight.analysis import AnalysisSession
+from pyhindsight.browsers.webbrowser import (
+    ARTIFACT_STATUS_FAILED,
+    ARTIFACT_STATUS_SKIPPED,
+    WebBrowser,
+)
+
+
+def _browser(counts=None, status=None):
+    browser = WebBrowser('profile', 'Chrome')
+    browser.artifacts_counts = dict(counts or {})
+    browser.artifacts_status = dict(status or {})
+    return browser
+
+
+class TestFinalizeArtifactStatus(unittest.TestCase):
+    """Parsers write 'Failed' into the counts dict; finalization splits it back out."""
+
+    def test_failure_moves_out_of_counts_into_status(self):
+        browser = _browser({'History': 500, 'Cookies': 'Failed'})
+        browser.finalize_artifact_status()
+        self.assertEqual({'History': 500}, browser.artifacts_counts)
+        self.assertEqual({'Cookies': ARTIFACT_STATUS_FAILED}, browser.artifacts_status)
+
+    def test_failure_does_not_become_a_count_of_zero(self):
+        # The bug this replaces: a failed parse used to be reported as "found nothing".
+        browser = _browser({'Cookies': 'Failed'})
+        browser.finalize_artifact_status()
+        self.assertNotIn('Cookies', browser.artifacts_counts)
+
+    def test_genuine_zero_count_is_left_alone(self):
+        # The other half of the distinction: 0 is a real, parsed result.
+        browser = _browser({'IndexedDB': 0})
+        browser.finalize_artifact_status()
+        self.assertEqual({'IndexedDB': 0}, browser.artifacts_counts)
+        self.assertEqual({}, browser.artifacts_status)
+
+    def test_unrecognized_status_is_preserved_not_rejected(self):
+        # The old merge raised ValueError on any status that wasn't 'Fail...'. A status
+        # nobody anticipated is still information; losing it is how failures went missing.
+        browser = _browser({'Cache': 'Aborted'})
+        browser.finalize_artifact_status()
+        self.assertEqual({'Cache': 'aborted'}, browser.artifacts_status)
+        self.assertNotIn('Cache', browser.artifacts_counts)
+
+    def test_is_idempotent(self):
+        browser = _browser({'History': 5, 'Cookies': 'Failed'})
+        browser.finalize_artifact_status()
+        browser.finalize_artifact_status()
+        self.assertEqual({'History': 5}, browser.artifacts_counts)
+        self.assertEqual({'Cookies': ARTIFACT_STATUS_FAILED}, browser.artifacts_status)
+
+    def test_existing_status_entries_survive(self):
+        # A skip recorded during the run must not be clobbered by finalization.
+        browser = _browser({'History': 5}, {'Cache': ARTIFACT_STATUS_SKIPPED})
+        browser.finalize_artifact_status()
+        self.assertEqual({'Cache': ARTIFACT_STATUS_SKIPPED}, browser.artifacts_status)
+
+
+class TestSumDictCounts(unittest.TestCase):
+
+    def test_sums_shared_keys(self):
+        self.assertEqual(
+            {'History': 30, 'Cookies': 5},
+            AnalysisSession.sum_dict_counts({'History': 10, 'Cookies': 5}, {'History': 20}))
+
+    def test_keys_only_in_one_dict_are_kept(self):
+        self.assertEqual(
+            {'History': 10, 'Cookies': 5},
+            AnalysisSession.sum_dict_counts({'History': 10}, {'Cookies': 5}))
+
+    def test_a_status_string_is_a_loud_error_not_a_silent_zero(self):
+        # Previously this returned {'Cookies': 0}, reporting a failed parse as an empty
+        # one. Reaching here now means finalize_artifact_status() was bypassed.
+        with self.assertRaises(TypeError) as raised:
+            AnalysisSession.sum_dict_counts({}, {'Cookies': 'Failed'})
+        self.assertIn('finalize_artifact_status', str(raised.exception))
+
+
+class TestSessionStatusAggregation(unittest.TestCase):
+    """Failures have to stay attached to the profile they happened in."""
+
+    def _session(self, *profiles):
+        session = AnalysisSession()
+        session.profile_paths = [name for name, _, _ in profiles]
+        for name, counts, status in profiles:
+            browser = _browser(counts, status)
+            session.artifacts_counts = session.sum_dict_counts(
+                session.artifacts_counts, browser.artifacts_counts)
+            session.record_artifact_status(name, browser)
+        return session
+
+    def test_status_is_recorded_per_profile(self):
+        session = self._session(
+            ('/p1', {'Cookies': 50}, {}),
+            ('/p2', {}, {'Cookies': ARTIFACT_STATUS_FAILED}))
+        self.assertEqual({'/p2': {'Cookies': ARTIFACT_STATUS_FAILED}}, session.artifacts_status)
+
+    def test_a_failure_in_one_profile_is_not_hidden_by_another_profiles_count(self):
+        # The old merge returned {'Cookies': 50} with no trace that a profile failed.
+        session = self._session(
+            ('/p1', {'Cookies': 50}, {}),
+            ('/p2', {}, {'Cookies': ARTIFACT_STATUS_FAILED}))
+        self.assertEqual(50, session.artifacts_counts['Cookies'])
+        self.assertEqual('failed in 1 of 2 profiles', session.describe_artifact_status('Cookies'))
+
+    def test_summary_lists_the_affected_profiles(self):
+        session = self._session(
+            ('/p1', {}, {'Cache': ARTIFACT_STATUS_FAILED}),
+            ('/p2', {}, {'Cache': ARTIFACT_STATUS_FAILED}))
+        self.assertEqual(
+            {'Cache': {ARTIFACT_STATUS_FAILED: ['/p1', '/p2']}},
+            session.artifact_status_summary())
+
+    def test_single_profile_status_is_described_without_a_profile_count(self):
+        session = self._session(('/p1', {}, {'Cache': ARTIFACT_STATUS_SKIPPED}))
+        self.assertEqual('skipped', session.describe_artifact_status('Cache'))
+
+    def test_artifact_with_no_status_describes_as_none(self):
+        session = self._session(('/p1', {'History': 10}, {}))
+        self.assertIsNone(session.describe_artifact_status('History'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
…acts

- Introduce an artifact filtering mechanism to allow `--only` and `--skip` options for fine-grained artifact parsing.
- Define browser-neutral artifact names and groups, enabling consistent CLI usage across Chrome and Firefox profiles.
- Implement error handling for unknown artifact names with suggestions for valid options.
- Provide unit tests for artifact resolution, filtering logic, catalog integrity, and parser call site validation.
- Ensure artifact filtering impacts both processing logic and live UI displays.