### PR TITLE
Refactor parsing counts and display

### DIFF
--- a/hindsight.py
+++ b/hindsight.py
@@ -447,6 +447,10 @@ def main():
     output_table.add_row("Log path", os.path.abspath(analysis_session.log_path))
     output_table.add_row("Format", analysis_session.selected_output_format.upper())
     output_table.add_row("Total items", str(total_items))
+    unparsed_summary = analysis_session.describe_unparsed_totals()
+    if unparsed_summary:
+        # Surfaced next to the total so a partial run is never read as a complete one.
+        output_table.add_row("Unparsed", rich.text.Text(unparsed_summary, style="yellow"))
     output_table.add_row("Elapsed time", elapsed_str)
     output_table.add_row("Finish time", finish_time)
     console.print(rich.align.Align.center(output_table))

--- a/hindsight_gui.py
+++ b/hindsight_gui.py
@@ -207,9 +207,15 @@ def display_results():
     return bottle.template('templates/results.tpl', {
         'js_installed': os.path.exists(
             os.path.join(STATIC_PATH, 'web_modules/sqlite-view.js')),
-        # A method, so it isn't in __dict__; the artifacts table needs it to show
-        # "failed" instead of a count of 0 for an artifact that couldn't be parsed.
+        # These are derived from artifact_results rather than stored, so they are
+        # properties and don't appear in __dict__. The artifacts table needs all of
+        # them -- the status ones so an artifact that couldn't be parsed shows as
+        # "failed" rather than as a count of 0.
+        'artifacts_counts': analysis_session.artifacts_counts,
+        'artifacts_display': analysis_session.artifacts_display,
+        'artifacts_status': analysis_session.artifacts_status,
         'artifact_status_summary': analysis_session.artifact_status_summary(),
+        'artifact_status_descriptions': analysis_session.artifact_status_descriptions(),
         **analysis_session.__dict__
         })
 

--- a/pyhindsight/analysis.py
+++ b/pyhindsight/analysis.py
@@ -1,5 +1,6 @@
 import datetime
 import importlib
+import collections
 import json
 import logging
 import os
@@ -15,7 +16,8 @@ from pyhindsight import __version__
 from pyhindsight.artifact_filter import ArtifactFilter
 from pyhindsight.browsers.chrome import Chrome
 from pyhindsight.browsers.firefox import Firefox
-from pyhindsight.browsers.webbrowser import WebBrowser, timeline_sort_key
+from pyhindsight.browsers.webbrowser import (
+    ARTIFACT_STATUS_FAILED, ARTIFACT_STATUS_SKIPPED, WebBrowser, timeline_sort_key)
 from pyhindsight.utils import friendly_date
 import pyhindsight.plugins
 import rich.align
@@ -490,12 +492,11 @@ class AnalysisSession(object):
         self.available_decrypts = available_decrypts
         self.selected_decrypts = selected_decrypts
         self.parsed_artifacts = parsed_artifacts
-        self.artifacts_display = artifacts_display
-        self.artifacts_counts = artifacts_counts
-        # {profile_path: {count_key: status}} for artifacts that produced an outcome
-        # rather than a count (a failed or skipped parse). Kept separate from
-        # artifacts_counts so a count is always a count.
-        self.artifacts_status = {}
+        # {profile_path: {artifact key: ArtifactResult}} -- the authoritative record of
+        # what every profile produced. Counts are summed across profiles for display,
+        # but an outcome ("the Cookies DB failed") is only meaningful attached to the
+        # profile it happened in, so the per-profile shape is what gets stored.
+        self.artifact_results = {}
         # Which artifacts this run is allowed to parse. A permissive filter by default,
         # so nothing changes for callers that don't set one. The same object is shared
         # by every profile's browser object, so its record of what was skipped covers
@@ -522,9 +523,6 @@ class AnalysisSession(object):
 
         if self.parsed_artifacts is None:
             self.parsed_artifacts = []
-
-        if self.artifacts_counts is None:
-            self.artifacts_counts = {}
 
         if self.parsed_storage is None:
             self.parsed_storage = []
@@ -610,41 +608,139 @@ class AnalysisSession(object):
                     log.warning(f'Error reading config file {config_path}: {e}')
         return {}
 
-    @staticmethod
-    def sum_dict_counts(dict1, dict2):
-        """Combine two dicts of record counts by summing the values of shared keys.
+    def record_profile_results(self, profile_path, browser_analysis):
+        """Store one profile's artifact records, keyed by the profile they came from.
 
-        Both dicts hold counts only. Non-count outcomes (a failed or skipped parse) live
-        in `artifacts_status` and are removed from the counts by
-        `WebBrowser.finalize_artifact_status()` before aggregation, so there is nothing
-        to special-case here.
-
-        This used to accept a ``'Failed'`` sentinel and resolve it by substituting ``0``,
-        which reported a failed parse as "found nothing" -- and, when another profile had
-        parsed the same artifact, dropped the failure entirely. A non-numeric value now
-        means a caller bypassed finalization, which is a bug worth surfacing rather than
-        papering over with a zero.
+        Replaces the old three-dict merge. Counts used to be summed into a single
+        session dict as each profile finished, which threw away which profile a number
+        came from -- and, when an artifact failed in one profile but parsed in another,
+        threw away the failure entirely.
         """
-        for key, value in list(dict2.items()):
-            if isinstance(value, str):
-                raise TypeError(
-                    f"artifacts_counts['{key}'] is the string {value!r}; counts must be "
-                    f"numeric. Status values belong in artifacts_status -- call "
-                    f"finalize_artifact_status() on the browser before aggregating.")
-            dict1[key] = dict1.setdefault(key, 0) + value
-        return dict1
+        results = getattr(browser_analysis, 'artifact_results', None)
+        if not results:
+            return
+        self.artifact_results.setdefault(profile_path, {}).update(results)
+        # Nothing is logged here: log_unparsed_summary() reports the same artifacts at
+        # the end of the run, better formatted and without repeating the profile path on
+        # every line. This used to log them too, immediately above that summary.
 
-    def record_artifact_status(self, profile_path, browser_analysis):
-        """Record one profile's non-count artifact outcomes (failed / skipped).
+    @property
+    def artifacts_counts(self):
+        """{artifact key: total records across all profiles}.
 
-        Kept per profile: summing counts across profiles is fine, but "the Cookies DB
-        failed" is only meaningful attached to the profile it failed in.
+        Derived, so it cannot drift from `artifact_results`. Artifacts that produced no
+        count (failed or skipped) are absent rather than zero.
         """
-        statuses = getattr(browser_analysis, 'artifacts_status', None)
-        if statuses:
-            self.artifacts_status.setdefault(profile_path, {}).update(statuses)
-            for count_key, status in sorted(statuses.items()):
-                log.info(f' - {count_key}: {status} ({profile_path})')
+        totals = {}
+        for results in self.artifact_results.values():
+            for key, result in results.items():
+                if result.count is not None:
+                    totals[key] = totals.get(key, 0) + result.count
+        return totals
+
+    @property
+    def artifacts_display(self):
+        """{artifact key: human-readable label}, merged across profiles."""
+        labels = {}
+        for results in self.artifact_results.values():
+            for key, result in results.items():
+                if result.label is not None:
+                    labels[key] = result.label
+        return labels
+
+    @property
+    def artifacts_status(self):
+        """{profile_path: {artifact key: status}} for artifacts that aren't a clean count."""
+        return {
+            profile: {k: r.status for k, r in results.items() if r.status is not None}
+            for profile, results in self.artifact_results.items()
+            if any(r.status is not None for r in results.values())
+        }
+
+    def artifact_status_descriptions(self):
+        """{artifact key: one-line status} for every artifact that isn't a clean count.
+
+        Built for output that shows one row per artifact; a partial parse describes
+        what was lost rather than just saying "partial".
+        """
+        described = {}
+        for key in self.artifact_status_summary():
+            description = self.describe_artifact_status(key)
+            if description:
+                described[key] = description
+        return described
+
+    def log_unparsed_summary(self):
+        """Write a consolidated "what was not parsed" block at the end of the run.
+
+        The per-artifact lines are correct but scattered through hundreds of lines of
+        progress output. This gathers them in one place, per profile, with the reason
+        attached, so "what is missing from this report, and why" has a single answer.
+
+        Formatted like the rest of the log -- a heading, then ` - ` items and `   - `
+        sub-items -- rather than as a banner, so it reads as part of the run.
+        """
+        anything = False
+        for profile_path, results in sorted(self.artifact_results.items()):
+            notable = [r for r in results.values() if r.status or r.is_partial]
+            if not notable:
+                continue
+            if not anything:
+                log.info('Not Parsed items (summary)')
+                anything = True
+            log.info(f' - Profile: {profile_path}')
+            for result in sorted(notable, key=lambda r: (r.status or '', r.key)):
+                label = result.label or result.key
+                if result.status == ARTIFACT_STATUS_SKIPPED:
+                    log.info(f'   - {label}: not parsed; excluded by --only/--skip')
+                elif result.status == ARTIFACT_STATUS_FAILED:
+                    reason = result.detail or 'reason not recorded'
+                    log.info(f'   - {label}: not parsed; {reason}')
+                elif result.is_partial:
+                    log.info(f'   - {label}: parsed {result.count}, '
+                             f'{result.describe_unparsed()}; each one is logged above '
+                             f'as "Unparsed source in {result.key}" / '
+                             f'"Unparsed record in {result.key}"')
+        if anything:
+            sources, records, artifacts = self.unparsed_totals()
+            if sources or records:
+                log.info(f' - Totals: {sources} source(s) and {records} record(s) '
+                         f'unparsed across {artifacts} artifact(s)')
+                if sources:
+                    log.info('   - An unparsed source is a whole store or file that '
+                             'could not be opened; how much it held is unknown, so '
+                             'counts for that artifact are a floor, not a total')
+
+    def unparsed_totals(self):
+        """(sources, records, artifacts) not read across the whole run.
+
+        Sources and records are counted separately because they answer different
+        questions: unparsed records are a bounded loss within a source that *was*
+        enumerated, while an unparsed source could have held any number of records, so
+        it caps what the run's totals can be used to claim.
+        """
+        sources = records = artifacts = 0
+        for results in self.artifact_results.values():
+            for result in results.values():
+                if result.is_partial:
+                    artifacts += 1
+                    sources += result.unparsed_sources
+                    records += result.unparsed_records
+        return sources, records, artifacts
+
+    def describe_unparsed_totals(self):
+        """One line for the end-of-run summary, or None if nothing was lost."""
+        sources, records, artifacts = self.unparsed_totals()
+        if not (sources or records):
+            return None
+        parts = []
+        if sources:
+            parts.append(f'{sources} source{"s" if sources != 1 else ""}')
+        if records:
+            parts.append(f'{records} record{"s" if records != 1 else ""}')
+        # The caller labels this row "Unparsed"; repeating the word here just pads it.
+        return (f'{", ".join(parts)} across '
+                f'{artifacts} artifact{"s" if artifacts != 1 else ""}')
 
     def artifact_status_summary(self):
         """Flatten per-profile statuses to {count_key: {status: [profile, ...]}}.
@@ -668,6 +764,19 @@ class AnalysisSession(object):
         statuses = self.artifact_status_summary().get(count_key)
         if not statuses:
             return None
+        # For a partial parse, the useful answer is what was lost, not the word
+        # "partial"; the counts are summed across the profiles that reported them.
+        if set(statuses) == {'partial'}:
+            sources = sum(r.unparsed_sources for results in self.artifact_results.values()
+                          for k, r in results.items() if k == count_key)
+            records = sum(r.unparsed_records for results in self.artifact_results.values()
+                          for k, r in results.items() if k == count_key)
+            parts = []
+            if sources:
+                parts.append(f'{sources} source{"s" if sources != 1 else ""}')
+            if records:
+                parts.append(f'{records} record{"s" if records != 1 else ""}')
+            return f'{", ".join(parts)} unparsed'
         total_profiles = len(self.profile_paths or []) or 1
         parts = []
         for status, profiles in sorted(statuses.items()):
@@ -959,11 +1068,7 @@ class AnalysisSession(object):
                 self.parsed_storage.extend(browser_analysis.parsed_storage)
                 self.parsed_extension_data.extend(browser_analysis.parsed_extension_data)
                 self.parsed_sync_data.extend(browser_analysis.parsed_sync_data)
-                self.artifacts_counts = self.sum_dict_counts(self.artifacts_counts, browser_analysis.artifacts_counts)
-                self.record_artifact_status(found_profile_path, browser_analysis)
-                if self.artifacts_display is None:
-                    self.artifacts_display = {}
-                self.artifacts_display.update(browser_analysis.artifacts_display)
+                self.record_profile_results(found_profile_path, browser_analysis)
                 self.version.extend(browser_analysis.version)
                 self.display_version = browser_analysis.display_version
                 self.preferences.extend(browser_analysis.preferences)
@@ -1004,11 +1109,7 @@ class AnalysisSession(object):
                 browser_analysis.process()
                 self.parsed_artifacts.extend(browser_analysis.parsed_artifacts)
                 self.parsed_storage.extend(browser_analysis.parsed_storage)
-                self.artifacts_counts = self.sum_dict_counts(self.artifacts_counts, browser_analysis.artifacts_counts)
-                self.record_artifact_status(found_profile_path, browser_analysis)
-                if self.artifacts_display is None:
-                    self.artifacts_display = {}
-                self.artifacts_display.update(browser_analysis.artifacts_display)
+                self.record_profile_results(found_profile_path, browser_analysis)
                 self.version.extend(browser_analysis.version)
                 self.display_version = browser_analysis.display_version
                 self.preferences.extend(browser_analysis.preferences)
@@ -1031,6 +1132,7 @@ class AnalysisSession(object):
 
         self.apply_originator_visit_sources()
         self.generate_display_version()
+        self.log_unparsed_summary()
         return True
 
     def apply_originator_visit_sources(self):
@@ -3069,12 +3171,20 @@ class AnalysisSession(object):
     def generate_jsonl(self, output_file):
         with open(output_file, mode='w') as jsonl:
             unparsed_count = 0
+            unparsed_types = collections.Counter()
 
             def write_jsonl_record(record):
                 nonlocal unparsed_count
                 record_json = json.dumps(record, cls=HindsightEncoder)
                 if record_json == 'null':
+                    # HindsightEncoder has no branch for this class, so the record is
+                    # dropped from the output entirely. Naming the class and row_type
+                    # makes that diagnosable -- a bare count hides which artifact is
+                    # missing, and "some records were skipped" reads as harmless.
                     unparsed_count += 1
+                    unparsed_types[
+                        f'{type(record).__module__.split(".")[-1]}.{type(record).__name__}'
+                        f' (row_type={getattr(record, "row_type", None)!r})'] += 1
                     return
                 jsonl.write(record_json)
                 jsonl.write('\n')
@@ -3130,4 +3240,9 @@ class AnalysisSession(object):
                 for extension in installed_extensions['data']:
                     write_jsonl_record(extension)
             if unparsed_count:
-                log.warning(f'Skipped {unparsed_count} unparsed JSONL record(s)')
+                log.error(
+                    f'{unparsed_count} record(s) could not be written to JSONL and are '
+                    f'MISSING from this output; HindsightEncoder has no branch for '
+                    f'their class:')
+                for name, count in unparsed_types.most_common():
+                    log.error(f'  - {count} x {name}')

--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -17,7 +17,8 @@ import puremagic
 import base64
 import ccl_chromium_reader
 
-from pyhindsight.browsers.webbrowser import WebBrowser, timeline_sort_key
+from pyhindsight.browsers.webbrowser import (
+    ParseFailures, WebBrowser, timeline_sort_key)
 from pyhindsight import utils
 
 # Try to import optional modules - do nothing on failure, as status is tracked elsewhere
@@ -298,14 +299,12 @@ class Chrome(WebBrowser):
         self.version = possible_versions
 
     @contextmanager
-    def _execute_compatible_query(self, path, database, query, version, artifact_name, count_key=None):
+    def _execute_compatible_query(self, path, database, query, version, artifact_name):
         """Open *database*, find the highest compatible query version, execute it with schema fallback, yield cursor.
 
         Yields None (and logs) on any failure so callers can do ``if cursor is None: return``.
         The DB connection is always closed on exit.
         """
-        if count_key is None:
-            count_key = database
 
         compatible_version = version[0]
         while compatible_version not in query and compatible_version > 0:
@@ -320,7 +319,6 @@ class Chrome(WebBrowser):
 
         conn = utils.open_sqlite_db(self, path, database)
         if not conn:
-            self.artifacts_counts[count_key] = 'Failed'
             yield None
             return
 
@@ -338,7 +336,6 @@ class Chrome(WebBrowser):
                     log.warning(f' - Query for {artifact_name} v{attempt_version} failed ({e}); trying lower version')
             else:
                 log.error(f' - No compatible query found for {artifact_name}; skipping')
-                self.artifacts_counts[count_key] = 'Failed'
                 yield None
                 return
             yield cursor
@@ -425,7 +422,7 @@ class Chrome(WebBrowser):
         source_item = os.path.relpath(os.path.join(path, history_file), self.profile_path)
         with self._execute_compatible_query(path, history_file, query, version, 'History items') as cursor:
             if cursor is None:
-                return
+                return None
 
             for row in cursor:
                 duration = None
@@ -487,9 +484,8 @@ class Chrome(WebBrowser):
                 new_row.source_item = source_item
                 results.append(new_row)
 
-        self.artifacts_counts[history_file] = len(results)
-        log.info(f' - Parsed {len(results)} items')
         self.parsed_artifacts.extend(results)
+        return len(results)
 
     def get_media_history(self, path, history_file, version, row_type):
         results = []
@@ -506,7 +502,7 @@ class Chrome(WebBrowser):
         source_item = os.path.relpath(os.path.join(path, history_file), self.profile_path)
         with self._execute_compatible_query(path, history_file, query, version, 'Media History items') as cursor:
             if cursor is None:
-                return
+                return None
 
             for row in cursor:
                 duration = None
@@ -536,9 +532,8 @@ class Chrome(WebBrowser):
                 new_row.source_item = source_item
                 results.append(new_row)
 
-        self.artifacts_counts[history_file] = len(results)
-        log.info(f' - Parsed {len(results)} items')
         self.parsed_artifacts.extend(results)
+        return len(results)
 
     @staticmethod
     def _download_interpretation(item):
@@ -576,6 +571,7 @@ class Chrome(WebBrowser):
     def get_downloads(self, path, database, version, row_type):
         # Set up empty return array
         results = []
+        unparsed = ParseFailures('Downloads')
 
         log.info(f'Download items from {database}:')
 
@@ -636,10 +632,9 @@ class Chrome(WebBrowser):
 
         source_item = os.path.relpath(os.path.join(path, database), self.profile_path)
         with self._execute_compatible_query(
-                path, database, query, version, 'Download items',
-                count_key=database + '_downloads') as cursor:
+                path, database, query, version, 'Download items') as cursor:
             if cursor is None:
-                return
+                return None
 
             # The downloads_url_chains join returns one row per redirect hop; collapse to one
             # entry per download, collecting the full URL chain (final hop = download URL).
@@ -677,7 +672,7 @@ class Chrome(WebBrowser):
                         by_ext_name=row.get('by_ext_name'), by_web_app_id=row.get('by_web_app_id'),
                         url_chain=ordered_chain if len(ordered_chain) > 1 else None)
                 except Exception:
-                    log.exception(' - Exception processing record; skipped.')
+                    unparsed.record('download record', 'exception while processing')
                     continue
 
                 new_row.decode_interrupt_reason()
@@ -710,9 +705,8 @@ class Chrome(WebBrowser):
                     opened_row.row_type = f'{row_type} (opened)'
                     results.append(opened_row)
 
-        self.artifacts_counts[database + '_downloads'] = len(results)
-        log.info(f' - Parsed {len(results)} items')
         self.parsed_artifacts.extend(results)
+        return unparsed.result(len(results))
 
     def get_shared_proto_db_downloads(self, path, dir_name):
         # Downloads persisted by Chrome's in-progress DownloadDB in the shared_proto_db
@@ -732,6 +726,7 @@ class Chrome(WebBrowser):
         }
 
         results = []
+        unparsed = ParseFailures('shared_proto_db downloads')
         ldb_path = os.path.join(path, dir_name)
         log.info('Downloads (shared_proto_db):')
         log.info(f' - Reading from {ldb_path}')
@@ -739,8 +734,7 @@ class Chrome(WebBrowser):
 
         if not os.path.isdir(ldb_path):
             log.error(f' - {ldb_path} is not a directory')
-            self.artifacts_counts['shared_proto_db downloads'] = 'Failed'
-            return
+            return None
 
         def decode_string16_pickle(raw):
             # target_path/current_path are serialized base::Pickle string16 blobs:
@@ -757,8 +751,7 @@ class Chrome(WebBrowser):
             ldb_records = ccl_chromium_reader.storage_formats.ccl_leveldb.RawLevelDb(pathlib.Path(ldb_path))
         except ValueError as e:
             log.warning(f' - Error reading records ({e}); possible LevelDB corruption')
-            self.artifacts_counts['shared_proto_db downloads'] = 'Failed'
-            return
+            return None
 
         # Keep the latest (highest-seq) Live record per download guid; the in-progress DB
         # rewrites a download's entry as it progresses, so earlier records are partial
@@ -772,7 +765,7 @@ class Chrome(WebBrowser):
             try:
                 entry = DownloadDBEntry.FromString(record.value)
             except Exception as e:
-                log.debug(f' - Could not decode a shared_proto_db download record: {e}')
+                unparsed.record('shared_proto_db download', f'could not decode ({e})')
                 continue
             guid = entry.download_info.guid
             if guid not in latest_by_guid or record.seq > latest_by_guid[guid][0]:
@@ -829,7 +822,7 @@ class Chrome(WebBrowser):
                     fetched_via_service_worker=ip.fetched_via_service_worker or None,
                     storage_partition=storage_partition)
             except Exception:
-                log.exception(' - Exception processing shared_proto_db download; skipped.')
+                unparsed.record('shared_proto_db download', 'exception while processing')
                 continue
 
             new_row.decode_interrupt_reason()
@@ -845,9 +838,8 @@ class Chrome(WebBrowser):
             new_row.source_item = source_item
             results.append(new_row)
 
-        self.artifacts_counts['shared_proto_db downloads'] = len(results)
-        log.info(f' - Parsed {len(results)} items')
         self.parsed_artifacts.extend(results)
+        return unparsed.result(len(results))
 
     def decrypt_cookie(self, encrypted_value):
         """Decryption based on work by Nathan Henrie and Jordan Wright as well as Chromium source:
@@ -953,7 +945,7 @@ class Chrome(WebBrowser):
         source_item = os.path.relpath(os.path.join(path, database), self.profile_path)
         with self._execute_compatible_query(path, database, query, version, 'Cookie items') as cursor:
             if cursor is None:
-                return
+                return None
 
             for row in cursor:
                 if row.get('encrypted_value') is not None:
@@ -1006,9 +998,8 @@ class Chrome(WebBrowser):
                     updated_row.timestamp = updated_row.last_update_utc
                     results.append(updated_row)
 
-        self.artifacts_counts[database] = len(results)
-        log.info(f' - Parsed {len(results)} items')
         self.parsed_artifacts.extend(results)
+        return len(results)
 
     def get_login_data(self, path, database, version):
         # Set up empty return array
@@ -1028,7 +1019,7 @@ class Chrome(WebBrowser):
         source_item = os.path.relpath(os.path.join(path, database), self.profile_path)
         with self._execute_compatible_query(path, database, query, version, 'Login items') as cursor:
             if cursor is None:
-                return
+                return None
 
             for row in cursor:
                 if row.get('blacklisted_by_user') == 1:
@@ -1103,9 +1094,8 @@ class Chrome(WebBrowser):
                     stats_row.source_item = source_item
                     results.append(stats_row)
 
-        self.artifacts_counts['Login Data'] = len(results)
-        log.info(f' - Parsed {len(results)} items')
         self.parsed_artifacts.extend(results)
+        return len(results)
 
     def get_autofill(self, path, database, version):
         # Set up empty return array
@@ -1121,9 +1111,9 @@ class Chrome(WebBrowser):
 
         source_item = os.path.relpath(os.path.join(path, database), self.profile_path)
         with self._execute_compatible_query(
-                path, database, query, version, 'Autofill items', count_key='Autofill') as cursor:
+                path, database, query, version, 'Autofill items') as cursor:
             if cursor is None:
-                return
+                return None
 
             for row in cursor:
                 autofill_value = row.get('value')
@@ -1143,9 +1133,8 @@ class Chrome(WebBrowser):
                     last_used_item.source_item = source_item
                     results.append(last_used_item)
 
-        self.artifacts_counts['Autofill'] = len(results)
-        log.info(f' - Parsed {len(results)} items')
         self.parsed_artifacts.extend(results)
+        return len(results)
 
     def get_dips(self, path, database, version):
         # Set up empty return array
@@ -1181,9 +1170,9 @@ class Chrome(WebBrowser):
 
         source_item = os.path.relpath(os.path.join(path, database), self.profile_path)
         with self._execute_compatible_query(
-                path, database, query, version, 'DIPS items', count_key='DIPS') as cursor:
+                path, database, query, version, 'DIPS items') as cursor:
             if cursor is None:
-                return
+                return None
 
             for row in cursor:
                 for column in columns:
@@ -1197,9 +1186,8 @@ class Chrome(WebBrowser):
                     dips_record.source_item = source_item
                     results.append(dips_record)
 
-        self.artifacts_counts['DIPS'] = len(results)
-        log.info(f' - Parsed {len(results)} items')
         self.parsed_artifacts.extend(results)
+        return len(results)
 
     def get_dips_popups(self, path, database, version):
         # Set up empty return array
@@ -1214,9 +1202,9 @@ class Chrome(WebBrowser):
         source_item = os.path.relpath(os.path.join(path, database), self.profile_path)
 
         with self._execute_compatible_query(
-                path, database, query, version, 'DIPS Popup items', count_key='DIPS Popups') as cursor:
+                path, database, query, version, 'DIPS Popup items') as cursor:
             if cursor is None:
-                return
+                return None
 
             for row in cursor:
                 if row.get('is_authentication_interaction'):
@@ -1232,9 +1220,8 @@ class Chrome(WebBrowser):
                 dips_popup_record.source_item = source_item
                 results.append(dips_popup_record)
 
-        self.artifacts_counts['DIPS Popups'] = len(results)
-        log.info(f' - Parsed {len(results)} items')
         self.parsed_artifacts.extend(results)
+        return len(results)
 
     def get_bookmarks(self, path, file, version):
         # Set up empty return array
@@ -1281,17 +1268,16 @@ class Chrome(WebBrowser):
                         process_bookmark_children(decoded_json['roots'][top_level_folder]['name'],
                                                   decoded_json['roots'][top_level_folder]['children'])
 
-            self.artifacts_counts['Bookmarks'] = len(results)
-            log.info(f' - Parsed {len(results)} items')
             self.parsed_artifacts.extend(results)
+            return len(results)
 
         except:
             log.error(f' - Error parsing "{bookmarks_path}"')
-            self.artifacts_counts['Bookmarks'] = 'Failed'
-            return
+            return None
 
     def get_local_storage(self, path, dir_name):
         results = []
+        unparsed = ParseFailures('Local Storage')
 
         # Grab file list of 'Local Storage' directory
         ls_path = os.path.join(path, dir_name)
@@ -1300,11 +1286,14 @@ class Chrome(WebBrowser):
 
         if not os.path.isdir(ls_path):
             log.error(f' - {ls_path} is not a directory')
-            self.artifacts_counts['Local Storage'] = 'Failed'
-            return
+            return None
 
         local_storage_listing = os.listdir(ls_path)
         log.debug(f' - {len(local_storage_listing)} files in Local Storage directory')
+        # Legacy per-origin .localstorage SQLite files only; the modern leveldb
+        # directory is counted separately below. Conflating the two reported
+        # "N items from 0 files" on every modern profile, because everything had
+        # come from leveldb and nothing had come from a legacy file.
         filtered_listing = []
 
         # Chrome v61+ used leveldb for LocalStorage, but kept old SQLite .localstorage files if upgraded.
@@ -1320,6 +1309,10 @@ class Chrome(WebBrowser):
                         self.profile_path, ls_item['origin'], ls_item['key'], ls_item['value'],
                         ls_item['seq'], ls_item['state'], str(ls_item['origin_file'])))
 
+        # Everything gathered so far came from the leveldb directory; anything added
+        # after this point came from a legacy .localstorage file.
+        leveldb_item_count = len(results)
+
         # Chrome v60 and earlier used a SQLite file (with a .localstorage file ext) for each origin
         for ls_file in local_storage_listing:
             if ls_file.startswith(('ftp', 'http', 'file', 'chrome-extension')) and ls_file.endswith('.localstorage'):
@@ -1332,6 +1325,7 @@ class Chrome(WebBrowser):
                     # Copy and connect to copy of the Local Storage SQLite DB
                     conn = utils.open_sqlite_db(self, ls_path, ls_file)
                     if not conn:
+                        unparsed.source(ls_file_path, self.describe_open_failure())
                         continue
                     cursor = conn.cursor()
 
@@ -1349,14 +1343,33 @@ class Chrome(WebBrowser):
                             source_path=os.path.join(ls_path, ls_file)))
 
                 except Exception as e:
-                    log.warning(f' - Error reading key/values from {ls_file_path}: {e}')
+                    unparsed.source(ls_file_path, f'key/values unreadable ({e})')
                 finally:
                     if conn is not None:
                         conn.close()
 
-        self.artifacts_counts['Local Storage'] = len(results)
-        log.info(f' - Parsed {len(results)} items from {len(filtered_listing)} files')
+        # Name where the records actually came from. A modern profile has only the
+        # leveldb directory, an upgraded one can have both, and saying "from N files"
+        # for either was wrong or meaningless.
+        legacy_item_count = len(results) - leveldb_item_count
+        has_leveldb = 'leveldb' in local_storage_listing
+        # The driver logs the total, so only say what that doesn't already cover: which
+        # of the two storage generations the records came from, when that is not the
+        # ordinary "everything came from leveldb".
+        if has_leveldb and filtered_listing:
+            plural = 's' if len(filtered_listing) != 1 else ''
+            log.info(f' - {leveldb_item_count} item(s) from the leveldb directory and '
+                     f'{legacy_item_count} from {len(filtered_listing)} legacy '
+                     f'.localstorage file{plural}')
+        elif filtered_listing:
+            plural = 's' if len(filtered_listing) != 1 else ''
+            log.info(f' - All items came from {len(filtered_listing)} legacy '
+                     f'.localstorage file{plural} (no leveldb directory)')
+        elif not has_leveldb:
+            log.info(' - No leveldb directory or legacy .localstorage files found')
+
         self.parsed_storage.extend(results)
+        return unparsed.result(len(results))
 
     # A SNSS LastActiveTime below this is base::TimeTicks, not a wall-clock time.
     # Chrome originally wrote this field as base::TimeTicks -- microseconds from an
@@ -1391,6 +1404,7 @@ class Chrome(WebBrowser):
 
     def get_sessions(self, path, dir_name):
         results = []
+        unparsed = ParseFailures('Sessions')
 
         from ccl_chromium_reader.ccl_chromium_snss2 import SnssFile, SnssFileType, NavigationEntry
         from ccl_chromium_reader.serialization_formats.ccl_easy_chromium_pickle import EasyPickleIterator
@@ -1402,8 +1416,7 @@ class Chrome(WebBrowser):
 
         if not os.path.isdir(sessions_path):
             log.error(f' - {sessions_path} is not a directory')
-            self.artifacts_counts['Sessions'] = 'Failed'
-            return
+            return None
 
         # Session file command IDs (SessionRestoreIdType)
         SESSION_TAB_CLOSED = 16
@@ -1435,10 +1448,16 @@ class Chrome(WebBrowser):
                     while True:
                         length_raw = f.read(2)
                         if not length_raw or len(length_raw) < 2:
+                            if length_raw:
+                                unparsed.source(filename, 'truncated: incomplete command '
+                                                        'length at end of file')
                             break
                         length = struct.unpack('<H', length_raw)[0]
                         data = f.read(length)
                         if len(data) < length:
+                            unparsed.source(filename, f'truncated: command needs {length} '
+                                                    f'bytes, {len(data)} available; '
+                                                    f'remaining commands not read')
                             break
                         cmd_id = data[0]
                         p = data[1:]
@@ -1531,7 +1550,7 @@ class Chrome(WebBrowser):
                                 pass
 
             except Exception as e:
-                log.debug(f' - Error reading structural commands from {filename}: {e}')
+                unparsed.source(filename, f'structural commands unreadable ({e})')
 
         log.info(f' - Session structure: {len(session_windows)} windows, {len(session_tabs)} tabs, '
                  f'{len(session_tab_groups)} tab groups')
@@ -1563,12 +1582,13 @@ class Chrome(WebBrowser):
                 parts.append(f'Extension: {tab["extension_app_id"]}')
 
             if tab.get('user_agent_override'):
-                parts.append(f'UA Override: {tab["user_agent_override"][:50]}')
+                parts.append(f'UA Override: {tab["user_agent_override"]}')
 
             return parts
 
         # Track exact duplicates across all session files; key is all meaningful content fields
         seen_nav_entries = set()
+        duplicate_nav_entries = 0
 
         for filename in sorted(os.listdir(sessions_path)):
             if filename.startswith('Session_'):
@@ -1626,11 +1646,15 @@ class Chrome(WebBrowser):
                                     tf = parsed_ps.top_frame
                                     if tf.form_elements:
                                         form_items = []
-                                        for fe in tf.form_elements[:10]:
+                                        for fe in tf.form_elements:
                                             if not fe.values or not any(v.strip() for v in fe.values):
                                                 continue  # skip fields with no meaningful values
                                             label = fe.name or '(unnamed)'
-                                            form_items.append(f'{label} [{fe.type}]: {fe.values[0][:50]}')
+                                            # Every value of every element, in full: a
+                                            # multi-value field (multi-select, repeated
+                                            # input) previously reported only its first.
+                                            values = ', '.join(v for v in fe.values if v.strip())
+                                            form_items.append(f'{label} [{fe.type}]: {values}')
                                         if form_items:
                                             value_parts.append(f'Form Data: {"; ".join(form_items)}')
                                     if tf.http_body and tf.http_body.elements:
@@ -1695,13 +1719,17 @@ class Chrome(WebBrowser):
                             command.has_post_data,
                         )
                         if dedup_key in seen_nav_entries:
+                            # The same navigation entry appears in more than one SNSS
+                            # command, so collapsing is correct -- but how many rows were
+                            # collapsed has to be visible, the way Firefox reports it.
+                            duplicate_nav_entries += 1
                             continue
                         seen_nav_entries.add(dedup_key)
 
                         results.append(item)
 
             except Exception as e:
-                log.warning(f' - Error reading {filename} (NavigationEntry pass): {e}')
+                unparsed.source(filename, f'NavigationEntry pass failed ({e})')
 
             # Pass 2: Read raw SNSS commands for timestamped events CCL doesn't parse
             try:
@@ -1710,10 +1738,16 @@ class Chrome(WebBrowser):
                     while True:
                         length_raw = f.read(2)
                         if not length_raw or len(length_raw) < 2:
+                            if length_raw:
+                                unparsed.source(filename, 'truncated: incomplete command '
+                                                        'length at end of file')
                             break
                         length = struct.unpack('<H', length_raw)[0]
                         data = f.read(length)
                         if len(data) < length:
+                            unparsed.source(filename, f'truncated: command needs {length} '
+                                                    f'bytes, {len(data)} available; '
+                                                    f'remaining commands not read')
                             break
 
                         cmd_id = data[0]
@@ -1830,7 +1864,7 @@ class Chrome(WebBrowser):
                                     log.debug(f' - Error parsing Window command in {filename}: {e}')
 
             except Exception as e:
-                log.warning(f' - Error reading {filename} (raw command pass): {e}')
+                unparsed.source(filename, f'raw command pass failed ({e})')
 
         # Build tab navigation stacks from NavigationEntry results
         # tab_nav_stacks: tab_id -> {nav_index: (url, title, timestamp)} (latest entry per index)
@@ -1866,9 +1900,15 @@ class Chrome(WebBrowser):
             'tab_nav_stacks': tab_nav_stacks,
         }
 
-        log.info(f' - Parsed {len(results)} Session items')
-        self.artifacts_counts['Sessions'] = len(results)
+        # Collapsed duplicates are reported, not just silently dropped: without the
+        # number there is no way to tell a session with few navigations from one whose
+        # rows were mostly merged. (Firefox's sessionstore parser reports the same way.)
+        if duplicate_nav_entries:
+            log.info(f' - Collapsed {duplicate_nav_entries} duplicate navigation '
+                     f'entr{"ies" if duplicate_nav_entries != 1 else "y"} '
+                     f'(same URL, title, timestamp, tab and index)')
         self.parsed_artifacts.extend(results)
+        return unparsed.result(len(results))
 
     def get_session_storage(self, path, dir_name):
         results = []
@@ -1881,8 +1921,7 @@ class Chrome(WebBrowser):
 
         if not os.path.isdir(ss_path):
             log.error(f' - {ss_path} is not a directory')
-            self.artifacts_counts['Session Storage'] = 'Failed'
-            return
+            return None
 
         session_storage_listing = os.listdir(ss_path)
         log.debug(f' - {len(session_storage_listing)} files in Session Storage directory')
@@ -1903,7 +1942,7 @@ class Chrome(WebBrowser):
             # The reader raises a range of errors on corrupt/truncated LevelDB data;
             # a single bad Session Storage shouldn't abort a multi-profile analysis.
             log.warning(f' - Error reading records ({e!r}); possible LevelDB corruption')
-            self.artifacts_counts['Session Storage'] = 'Failed'
+            return None
 
         if ss_ldb_records:
             for origin in ss_ldb_records.iter_hosts():
@@ -1929,10 +1968,9 @@ class Chrome(WebBrowser):
                     value.leveldb_sequence_number, state=record_state, source_path=ss_path))
 
             ss_ldb_records.close()
-            self.artifacts_counts['Session Storage'] = len(results)
 
-        log.info(f' - Parsed {len(results)} Session Storage items')
         self.parsed_storage.extend(results)
+        return len(results)
 
     @staticmethod
     def resolve_indexeddb_blob_refs(record, origin):
@@ -1970,6 +2008,7 @@ class Chrome(WebBrowser):
 
     def get_indexeddb(self, path, dir_name):
         results = []
+        unparsed = ParseFailures('IndexedDB')
 
         # Grab file list of 'IndexedDB' directory
         idb_path = os.path.join(path, dir_name)
@@ -1979,18 +2018,23 @@ class Chrome(WebBrowser):
 
         if not os.path.isdir(idb_path):
             log.error(f' - {idb_path} is not a directory')
-            self.artifacts_counts['IndexedDB'] = 'Failed'
-            return
+            return None
 
         idb_storage_listing = os.listdir(idb_path)
         log.debug(f' - {len(idb_storage_listing)} files in IndexedDB directory')
 
+        leveldb_dirs_read = 0
         for storage_directory in idb_storage_listing:
             if not storage_directory.endswith('.leveldb'):
                 continue
+            leveldb_dirs_read += 1
 
-            # The Ghostery extension has 1M+ records in it; skip for now.
+            # The Ghostery extension has 1M+ records in it; skip for now. Recorded
+            # as an unparsed source rather than skipped silently -- an examiner needs to
+            # know this origin was never read, not infer it from its absence.
             if storage_directory == 'chrome-extension_mlomiejdfkolichcflejclcbmpeaniij_0.indexeddb.leveldb':
+                unparsed.source(storage_directory,
+                              'skipped by hard-coded rule (very large store)')
                 continue
 
             origin = storage_directory.split('.indexeddb')[0]
@@ -2029,33 +2073,40 @@ class Chrome(WebBrowser):
                                     int(record.ldb_seq_no), database=f"{record.database_name}.{obj_store_name}",
                                     state=record_state, source_path=record_source_path))
                         except FileNotFoundError as e:
-                            log.error(f' - File ({e}) not found while processing {database}')
+                            unparsed.source(database, f'file not found ({e})')
 
                         except ValueError as e:
-                            log.error(f' - ValueError ({e}) when processing {database}')
+                            unparsed.source(database, f'ValueError ({e})')
 
                         except Exception as e:
                             # This aborts the rest of this object store's records, so name
                             # what was being read and how far it got -- otherwise there is
                             # no way to tell which data is missing from the output.
-                            log.error(f' - Unexpected Exception ({e}) when processing '
-                                      f'{database}.{obj_store_name}; '
-                                      f'{len(results)} records parsed before the failure')
+                            unparsed.source(
+                                f'{database}.{obj_store_name}',
+                                f'unexpected exception ({e}); {len(results)} records '
+                                f'parsed before the failure')
             except ValueError as e:
-                log.error(f' - {e} when processing {storage_directory}')
+                unparsed.source(storage_directory, str(e))
                 continue
 
             except Exception as e:
-                log.error(f' - Unexpected Exception ({e}) when processing {storage_directory}')
+                unparsed.source(storage_directory, f'unexpected exception ({e})')
                 continue
 
             finally:
                 if origin_idb is not None:
                     origin_idb.close()
 
-        self.artifacts_counts['IndexedDB'] = len(results)
-        log.info(f' - Parsed {len(results)} items from {len(idb_storage_listing)} files')
+        # Again, the driver logs the total; this says how many databases it came from,
+        # and only mentions the directory listing when it held entries that were not
+        # databases (blob directories, strays) so the two numbers differing is explained.
+        plural = 'ies' if leveldb_dirs_read != 1 else 'y'
+        skipped = len(idb_storage_listing) - leveldb_dirs_read
+        detail = f'; {skipped} non-database entr{"ies" if skipped != 1 else "y"} skipped'             if skipped else ''
+        log.info(f' - Read {leveldb_dirs_read} IndexedDB director{plural}{detail}')
         self.parsed_storage.extend(results)
+        return unparsed.result(len(results))
 
     @staticmethod
     def load_extension_manifest(extension_path):
@@ -2065,8 +2116,20 @@ class Chrome(WebBrowser):
         ext_version_listing = list(pathlib.Path(extension_path).glob("*.*_*"))
 
         # Connect to manifest.json in the latest version directory
-        # The version could be missing leading zeros in the string, so this sort accounts for that.
-        for version in sorted(ext_version_listing, reverse=True, key=lambda x: [int(part) for part in x.name.split('.')]):
+        # The version could be missing leading zeros in the string, so this sort accounts
+        # for that. Non-numeric components sort last rather than raising: one oddly-named
+        # directory used to abort the whole Extensions parse.
+        def version_sort_key(version_dir):
+            parts = []
+            for part in version_dir.name.split('.'):
+                # The sort is reverse=True (newest first), so a non-numeric component
+                # ranks *below* every numeric one to land last: a malformed directory
+                # should never be preferred over a real version, and must not crash the
+                # comparison the way int(part) did.
+                parts.append((1, int(part), '') if part.isdigit() else (0, 0, part))
+            return parts
+
+        for version in sorted(ext_version_listing, reverse=True, key=version_sort_key):
             manifest_path = version / 'manifest.json'
             try:
                 with open(manifest_path, encoding='utf-8', errors='replace') as f:
@@ -2102,10 +2165,10 @@ class Chrome(WebBrowser):
         log.info(f' - Reading from {extension_directory_path}')
         if not extension_directory_path.is_dir():
             log.error(f' - {extension_directory_path} is not a directory')
-            self.artifacts_counts['Extensions'] = 'Failed'
-            return
+            return None
 
         ext_listing = os.listdir(extension_directory_path)
+        unparsed = ParseFailures('Extensions')
         log.debug(f' - {len(ext_listing)} files in Extensions directory: {str(ext_listing)}')
 
         # Only process directories with the expected naming convention
@@ -2119,6 +2182,9 @@ class Chrome(WebBrowser):
             manifest, extension_version = self.load_extension_manifest(extension_directory_path / ext_id)
 
             if not manifest:
+                # load_extension_manifest() logs why; count it too, so the number of
+                # extensions reported is reconcilable with what is on disk.
+                unparsed.source(ext_id, 'manifest could not be read')
                 continue
 
             locale_messages = {}
@@ -2132,7 +2198,7 @@ class Chrome(WebBrowser):
                         with open(locale_messages_path, encoding='utf-8', errors='replace') as f:
                             locale_messages = json.load(f)
                     except (IOError, json.JSONDecodeError) as e:
-                        log.warning(f" - Error processing extension {ext_id}: {e}")
+                        unparsed.source(ext_id, f'manifest unreadable ({e})')
 
             name = self.get_localized_messages(locale_messages, manifest.get('name', ''))
             description = self.get_localized_messages(locale_messages, manifest.get('description', ''))
@@ -2159,9 +2225,8 @@ class Chrome(WebBrowser):
                 ext.content_scripts = manifest['content_scripts']
             disk_count += 1
 
-        self.artifacts_counts['Extensions'] = disk_count
-        log.info(f' - Parsed {disk_count} items')
         self._rebuild_installed_extensions()
+        return unparsed.result(disk_count)
 
     def _rebuild_installed_extensions(self):
         """Rebuild installed_extensions['data'] from the merged per-extension records.
@@ -2216,14 +2281,12 @@ class Chrome(WebBrowser):
                 prefs = json.loads(f.read())
         except Exception as e:
             log.exception(f' - Error decoding {preferences_file} file {pref_path}: {e}')
-            self.artifacts_counts[preferences_file] = 'Failed'
-            return
+            return None
 
         settings = prefs.get('extensions', {}).get('settings', {})
         if not settings:
             log.info(' - No extensions.settings found')
-            self.artifacts_counts[preferences_file] = 0
-            return
+            return 0
 
         timestamped_items = []
         count = 0
@@ -2334,9 +2397,9 @@ class Chrome(WebBrowser):
 
         self.parsed_artifacts.extend(timestamped_items)
         self._rebuild_installed_extensions()
-        self.artifacts_counts[preferences_file] = count
         log.info(f' - Parsed {count} extension settings entries '
                  f'({len(timestamped_items)} Timeline events)')
+        return count
 
     def get_preferences(self, path, preferences_file):
         def check_and_append_pref(parent, pref, value=None, description=None):
@@ -2555,8 +2618,7 @@ class Chrome(WebBrowser):
 
         except Exception as e:
             log.exception(f' - Error decoding Preferences file {pref_path}: {e}')
-            self.artifacts_counts[preferences_file] = 'Failed'
-            return
+            return None
 
         # Account Information
         if prefs.get('account_info'):
@@ -2968,8 +3030,7 @@ class Chrome(WebBrowser):
 
         self.parsed_artifacts.extend(timestamped_preference_items)
 
-        self.artifacts_counts[preferences_file] = len(results) + len(timestamped_preference_items)
-        log.info(f' - Parsed {self.artifacts_counts[preferences_file]} items')
+        preference_count = len(results) + len(timestamped_preference_items)
 
         try:
             profile_folder = os.path.split(path)[1]
@@ -2993,16 +3054,17 @@ class Chrome(WebBrowser):
                             ]}
 
         self.preferences.append({'data': results, 'presentation': presentation})
+        return preference_count
 
     def get_platform_notifications(self, path, dir_name):
         try:
             from ccl_chromium_reader.ccl_chromium_notifications import NotificationReader
         except ImportError as e:
             log.exception(f' - Exception importing ccl_chromium_notifications: {e}')
-            self.artifacts_counts['Platform Notifications'] = 'Failed'
-            return
+            return None
 
         result_list = []
+        unparsed = ParseFailures('Platform Notifications')
         log.info('Platform Notifications:')
         pn_root_path = os.path.join(path, dir_name)
         log.info(f' - Reading from {pn_root_path}')
@@ -3077,16 +3139,14 @@ class Chrome(WebBrowser):
                             result_list.append(click_record)
 
                     except Exception as e:
-                        log.warning(f' - Exception parsing notification: {e}')
+                        unparsed.record('platform notification', f'could not parse ({e})')
 
         except Exception as e:
             log.warning(f' - Could not open {pn_root_path} as LevelDB; {e}')
-            self.artifacts_counts['Platform Notifications'] = 'Failed'
-            return
+            return None
 
-        log.info(f' - Parsed {len(result_list)} items')
-        self.artifacts_counts['Platform Notifications'] = len(result_list)
         self.parsed_artifacts.extend(result_list)
+        return unparsed.result(len(result_list))
 
     def get_service_workers(self, path, dir_name):
         """Parse service worker registrations from the Service Worker/Database LevelDB.
@@ -3095,6 +3155,7 @@ class Chrome(WebBrowser):
         See content/browser/service_worker/service_worker_database.proto in Chromium.
         """
         results = []
+        unparsed = ParseFailures('Service Workers')
 
         sw_root_path = os.path.join(path, dir_name)
         ldb_path = os.path.join(sw_root_path, 'Database')
@@ -3103,8 +3164,7 @@ class Chrome(WebBrowser):
 
         if not os.path.isdir(ldb_path):
             log.error(f' - {ldb_path} is not a directory')
-            self.artifacts_counts['Service Workers'] = 'Failed'
-            return
+            return None
 
         log.info(f' - Using ccl_leveldb v{ccl_chromium_reader.storage_formats.ccl_leveldb.__version__}')
 
@@ -3113,8 +3173,7 @@ class Chrome(WebBrowser):
             ldb_records = ccl_chromium_reader.storage_formats.ccl_leveldb.RawLevelDb(pathlib.Path(ldb_path))
         except ValueError as e:
             log.warning(f' - Error reading records ({e}); possible LevelDB corruption')
-            self.artifacts_counts['Service Workers'] = 'Failed'
-            return
+            return None
 
         from pyhindsight.lib.proto.components.services.storage.service_worker.service_worker_database_pb2 import \
             ServiceWorkerRegistrationData, ServiceWorkerResourceRecord
@@ -3211,7 +3270,7 @@ class Chrome(WebBrowser):
                     try:
                         reg.ParseFromString(record.value)
                     except Exception as e:
-                        log.warning(f' - Failed to decode REG record: {e}')
+                        unparsed.record('REG record', f'could not decode ({e})')
                         continue
 
                     nav_preload_enabled = None
@@ -3410,7 +3469,7 @@ class Chrome(WebBrowser):
                 sc = ccl_chromium_reader.ccl_chromium_cache.ChromiumSimpleFileCache(
                     pathlib.Path(script_cache_path))
             except Exception as e:
-                log.warning(f' - Could not open ScriptCache as disk_cache: {e}')
+                unparsed.source('ScriptCache', f'could not be opened as disk_cache ({e})')
                 sc = None
             if sc is not None:
                 try:
@@ -3432,7 +3491,7 @@ class Chrome(WebBrowser):
                             metas = sc.get_metadata(cache_key)
                             infos = sc.get_entry_info(cache_key)
                         except Exception as e:
-                            log.warning(f' - Failed to read ScriptCache entry {cache_key}: {e}')
+                            unparsed.record(f'ScriptCache/{cache_key}', f'could not be read ({e})')
                             continue
                         for body, meta, info in zip(bodies, metas, infos):
                             body_sha = hashlib.sha256(body).hexdigest() if body else None
@@ -3539,7 +3598,9 @@ class Chrome(WebBrowser):
                         for cache_key in sc.keys():
                             try:
                                 file_names = sc.get_file_for_key(cache_key)
-                            except Exception:
+                            except Exception as e:
+                                unparsed.record(f'ScriptCache/{cache_key}',
+                                              f'could not resolve backing file ({e})')
                                 continue
                             for fname in file_names:
                                 scf_path = os.path.join(cache_subdir, fname)
@@ -3645,12 +3706,13 @@ class Chrome(WebBrowser):
                  f'{resource_count} resource records, {user_data_count} user-data records, '
                  f'{orphan_count} orphan registrations, {script_count} script bodies, '
                  f'{cache_storage_count} cache storage entries')
-        self.artifacts_counts['Service Workers'] = len(results)
         self.parsed_storage.extend(results)
+        return unparsed.result(len(results))
 
     def get_cache(self, path, dir_name, row_type=None):
         # Set up empty return array
         results = []
+        unparsed = ParseFailures(dir_name)
 
         cache_path_to_parse = pathlib.Path(path, dir_name)
         log.info(f'Cache items from {cache_path_to_parse}:')
@@ -3664,7 +3726,7 @@ class Chrome(WebBrowser):
         # Using any() - returns True if directory has any contents
         if not any(pathlib.Path(cache_path_to_parse).iterdir()):
             log.info(' - Cache path is empty')
-            return
+            return 0
 
         cache_items = profile.iterate_cache(url=None, omit_cached_data=False)
         source_item = os.path.relpath(os.path.join(path, dir_name), self.profile_path)
@@ -3672,6 +3734,11 @@ class Chrome(WebBrowser):
         try:
             for cache_item in cache_items:
                 if not cache_item.metadata:
+                    # No metadata means no URL, timestamp, or headers to attribute the
+                    # entry to; it is dropped, so say so rather than quietly shrinking
+                    # the count.
+                    unparsed.record(str(getattr(cache_item, 'key', '<unknown key>')),
+                                  'cache entry has no metadata')
                     continue
 
                 parsed_item = WebBrowser.CacheItem(
@@ -3691,12 +3758,10 @@ class Chrome(WebBrowser):
 
         except Exception as e:
             log.error(f' - Exception parsing Cache items: {e})', exc_info=True)
-            self.artifacts_counts[cache_display_name] = 'Failed'
-            return
+            return None
 
-        self.artifacts_counts[cache_display_name] = len(results)
-        log.info(f' - Parsed {len(results)} items')
         self.parsed_artifacts.extend(results)
+        return unparsed.result(len(results))
 
     def get_unified_extension_data(self, path, dir_name):
         results = []
@@ -3709,8 +3774,7 @@ class Chrome(WebBrowser):
 
         if not os.path.isdir(ldb_path):
             log.error(f' - {ldb_path} is not a directory')
-            self.artifacts_counts[f'{dir_name}'] = 'Failed'
-            return
+            return None
 
         ldb_file_listing = os.listdir(ldb_path)
         log.debug(f' - {len(ldb_file_listing)} files in {dir_name} directory')
@@ -3721,7 +3785,7 @@ class Chrome(WebBrowser):
             ldb_records = ccl_chromium_reader.storage_formats.ccl_leveldb.RawLevelDb(pathlib.Path(ldb_path))
         except ValueError as e:
             log.warning(f' - Error reading records ({e}); possible LevelDB corruption')
-            self.artifacts_counts[f'{dir_name}'] = 'Failed'
+            return None
 
         # For the 'Extension Scripts' StateStore, capture the latest (highest-seq,
         # non-deleted) 'dynamic_scripts' value per extension for the live merge, and ALSO
@@ -3761,29 +3825,28 @@ class Chrome(WebBrowser):
                             dynamic_scripts_raw[ext_id] = (record.seq, parsed.value)
 
             ldb_records.close()
-            self.artifacts_counts[f'{dir_name}'] = len(results)
 
         if dynamic_scripts_raw:
             self._merge_dynamic_scripts(dynamic_scripts_raw)
         if dynamic_scripts_all:
             self._carve_dynamic_scripts(dynamic_scripts_all)
 
-        log.info(f' - Parsed {len(results)} {dir_name} items')
         self.parsed_extension_data.extend(results)
+        return len(results)
 
     def get_dnr_extension_rules(self, path, dir_name):
         """Parse declarativeNetRequest DYNAMIC rules from
         ``<profile>/DNR Extension Rules/<ext_id>/rules.json``.
         """
         results = []
+        unparsed = ParseFailures('DNR Extension Rules')
         dnr_path = os.path.join(path, dir_name)
         log.info(f'{dir_name}:')
         log.info(f' - Reading from {dnr_path}')
 
         if not os.path.isdir(dnr_path):
             log.error(f' - {dnr_path} is not a directory')
-            self.artifacts_counts[dir_name] = 'Failed'
-            return
+            return None
 
         for ext_id in sorted(os.listdir(dnr_path)):
             ext_dir = os.path.join(dnr_path, ext_id)
@@ -3804,7 +3867,7 @@ class Chrome(WebBrowser):
                 with open(rules_json, encoding='utf-8', errors='replace') as f:
                     rules = json.load(f)
             except (OSError, json.JSONDecodeError) as e:
-                log.warning(f' - Error reading {rules_json}: {e}')
+                unparsed.source(rules_json, f'unreadable ({e})')
                 continue
 
             if not isinstance(rules, list):
@@ -3826,9 +3889,8 @@ class Chrome(WebBrowser):
                 parsed.row_type = dir_name.lower()
                 results.append(parsed)
 
-        self.artifacts_counts[dir_name] = len(results)
-        log.info(f' - Parsed {len(results)} {dir_name} items')
         self.parsed_extension_data.extend(results)
+        return unparsed.result(len(results))
 
     @staticmethod
     def _normalize_dynamic_script(entry):
@@ -4001,6 +4063,7 @@ class Chrome(WebBrowser):
 
     def get_partitioned_extension_data(self, path, dir_name):
         results = []
+        unparsed = ParseFailures('extension storage')
         any_failed = False
 
         # Grab file list of input directory
@@ -4009,8 +4072,7 @@ class Chrome(WebBrowser):
         log.info(f' - Reading from {top_path}')
         if not os.path.isdir(top_path):
             log.error(f' - {top_path} is not a directory')
-            self.artifacts_counts[f'{dir_name}'] = 'Failed'
-            return
+            return None
 
         top_file_listing = os.listdir(top_path)
 
@@ -4029,9 +4091,7 @@ class Chrome(WebBrowser):
             log.info(f' - Using ccl_leveldb v{ccl_chromium_reader.storage_formats.ccl_leveldb.__version__}')
 
             if not os.path.isdir(ldb_path):
-                log.error(f' - {ldb_path} is not a directory')
-                self.artifacts_counts[f'{dir_name}'] = 'Failed'
-                any_failed = True
+                unparsed.source(ldb_path, 'not a directory')
                 continue
 
             ldb_file_listing = os.listdir(ldb_path)
@@ -4042,8 +4102,7 @@ class Chrome(WebBrowser):
             try:
                 ldb_records = ccl_chromium_reader.storage_formats.ccl_leveldb.RawLevelDb(pathlib.Path(ldb_path))
             except ValueError as e:
-                log.warning(f' - Error reading records ({e}); possible LevelDB corruption')
-                self.artifacts_counts[f'{dir_name}'] = 'Failed'
+                unparsed.source(ldb_path, f'possible LevelDB corruption ({e})')
 
             if ldb_records:
                 for record in ldb_records.iterate_records_raw():
@@ -4058,12 +4117,11 @@ class Chrome(WebBrowser):
 
                 ldb_records.close()
 
-        if any_failed:
-            self.artifacts_counts[f'{dir_name}'] = 'Failed'
-        else:
-            self.artifacts_counts[f'{dir_name}'] = len(results)
-        log.info(f' - Parsed {len(results)} {dir_name} items')
         self.parsed_extension_data.extend(results)
+        # Whatever parsed is still emitted, and the count is kept: reporting the whole
+        # artifact as failed used to discard a usable count because one store of many
+        # was corrupt.
+        return unparsed.result(len(results))
 
     @staticmethod
     def parse_ls_ldb_record(record):
@@ -4201,6 +4259,7 @@ class Chrome(WebBrowser):
     def get_file_system(self, path, dir_name):
 
         result_list = []
+        unparsed = ParseFailures('File System')
         result_count = 0
 
         # Grab listing of 'File System' directory
@@ -4209,8 +4268,7 @@ class Chrome(WebBrowser):
         log.info(f' - Reading from {fs_root_path}')
         if not os.path.isdir(fs_root_path):
             log.error(f' - {fs_root_path} is not a directory')
-            self.artifacts_counts['File System'] = 'Failed'
-            return
+            return None
 
         fs_root_listing = os.listdir(fs_root_path)
         log.debug(f' - {len(fs_root_listing)} files in File System directory: {str(fs_root_listing)}')
@@ -4279,12 +4337,16 @@ class Chrome(WebBrowser):
                             name, ptr = utils.read_string(item['value'], ptr)
                             mod_time, ptr = utils.read_int64(item['value'], ptr)
 
-                            backing_files[item['key'].decode()] = {
+                            # Held in a local rather than re-subscripted below: the only
+                            # *read* of backing_files[...] should be the guarded lookup
+                            # in the CHILD_OF pass, where the key may not exist.
+                            backing_file = {
                                 'modification_time': mod_time,
                                 'seq': item['seq'],
                                 'state': item['state'],
                                 'source_path': item['origin_file']
                             }
+                            backing_files[item['key'].decode()] = backing_file
 
                             path_parts = re.split(r'[/\\]', backing_file_path)
                             # Need at least two segments to index [0] and [1]; a
@@ -4295,15 +4357,15 @@ class Chrome(WebBrowser):
                                     path_nodes['0']['fs_path'], fs_type, path_parts[0], path_parts[1])
                                 file_exists, file_size, magic_results = self.get_local_file_info(
                                            os.path.join(self.profile_path, normalized_backing_file_path))
-                                backing_files[item['key'].decode()]['file_exists'] = file_exists
-                                backing_files[item['key'].decode()]['file_size'] = file_size
-                                backing_files[item['key'].decode()]['magic_results'] = magic_results
+                                backing_file['file_exists'] = file_exists
+                                backing_file['file_size'] = file_size
+                                backing_file['magic_results'] = magic_results
 
                             else:
                                 normalized_backing_file_path = os.path.join(
                                     path_nodes['0']['fs_path'], fs_type, backing_file_path)
 
-                            backing_files[item['key'].decode()]['backing_file_path'] = normalized_backing_file_path
+                            backing_file['backing_file_path'] = normalized_backing_file_path
 
                     # Loop over records again, this time to add to the path_nodes dict (used later to construct
                     # the logical path for items in FileSystem. We look at deleted records here; while the value
@@ -4335,14 +4397,24 @@ class Chrome(WebBrowser):
                         }
 
                         if not item['value'] == b'':
-                            value_dict = {
-                                'fs_path': backing_files[item['value'].decode()]['backing_file_path'],
-                                'modification_time': backing_files[item['value'].decode()]['modification_time'],
-                                'file_exists': backing_files[item['value'].decode()].get('file_exists'),
-                                'file_size': backing_files[item['value'].decode()].get('file_size'),
-                                'magic_results': backing_files[item['value'].decode()].get('magic_results'),
-                            }
-                            path_nodes[path_node_key].update(value_dict)
+                            file_id = item['value'].decode()
+                            backing_file = backing_files.get(file_id)
+                            if backing_file is None:
+                                # The entry names a file_id with no surviving FileInfo
+                                # record (its own record was deleted). The name and
+                                # logical path are still recoverable, so keep the node
+                                # and record what could not be attached to it.
+                                unparsed.record(
+                                    f'{origin_domain} ({fs_type}) file_id {file_id}',
+                                    'no FileInfo record; path and metadata unavailable')
+                            else:
+                                path_nodes[path_node_key].update({
+                                    'fs_path': backing_file.get('backing_file_path'),
+                                    'modification_time': backing_file.get('modification_time'),
+                                    'file_exists': backing_file.get('file_exists'),
+                                    'file_size': backing_file.get('file_size'),
+                                    'magic_results': backing_file.get('magic_results'),
+                                })
 
                         result_count += 1
 
@@ -4362,7 +4434,10 @@ class Chrome(WebBrowser):
                         parent_node['children'][entry_id] = node
 
                     if '0' not in node_tree:
-                        log.debug(' - Missing root node; skipping logical path build for this origin')
+                        # Without a root there is no logical path to build, so this
+                        # origin's entries never reach the output at all.
+                        unparsed.source(f'{origin_domain} ({fs_type})',
+                                      'missing root node; logical paths not built')
                         continue
 
                     self.build_logical_fs_path(node_tree['0'])
@@ -4378,9 +4453,8 @@ class Chrome(WebBrowser):
                             magic_results=item.get('magic_results')
                         ))
 
-        log.info(f' - Parsed {len(result_list)} items')
-        self.artifacts_counts['File System'] = len(result_list)
         self.parsed_storage.extend(result_list)
+        return unparsed.result(len(result_list))
 
     def get_site_characteristics(self, path, dir_name):
         result_list = []
@@ -4394,8 +4468,7 @@ class Chrome(WebBrowser):
         # Grab listing of 'Site Characteristics' directory
         if not os.path.isdir(sc_root_path):
             log.error(f' - {sc_root_path} is not a directory')
-            self.artifacts_counts['Site Characteristics'] = 'Failed'
-            return
+            return None
 
         sc_root_listing = os.listdir(sc_root_path)
         log.debug(f' - {len(sc_root_listing)} files in Site Characteristics directory: {str(sc_root_listing)}')
@@ -4438,9 +4511,8 @@ class Chrome(WebBrowser):
             except Exception as e:
                 log.exception(f' - Exception parsing SiteDataProto ({item}): {e}')
 
-        log.info(f' - Parsed {len(result_list)} items')
-        self.artifacts_counts['Site Characteristics'] = len(result_list)
         self.parsed_artifacts.extend(result_list)
+        return len(result_list)
 
     def get_sync_data(self, path, dir_name):
         result_list = []
@@ -4452,8 +4524,7 @@ class Chrome(WebBrowser):
         # Grab listing of 'Sync Data' directory
         if not os.path.isdir(sync_data_root_path):
             log.error(f' - {sync_data_root_path} is not a directory')
-            self.artifacts_counts['Sync Data'] = 'Failed'
-            return
+            return None
 
         sd_root_listing = os.listdir(sync_data_root_path)
         log.debug(f' - {len(sd_root_listing)} files in Sync Data directory: {str(sd_root_listing)}')
@@ -4584,9 +4655,8 @@ class Chrome(WebBrowser):
                 file_type=item.get('file_type'))
             result_list.append(sync_record)
 
-        log.info(f' - Parsed {len(result_list)} items')
-        self.artifacts_counts['Sync Data'] = len(result_list)
         self.parsed_sync_data.extend(result_list)
+        return len(result_list)
 
     def build_hsts_domain_hashes(self):
         domains = self.get_clean_hostnames()
@@ -4685,11 +4755,10 @@ class Chrome(WebBrowser):
 
             else:
                 log.warning('Unable to process TransportSecurity file; could not determine version.')
-                return
+                return None
 
-        log.info(f' - Parsed {len(result_list)} items')
-        self.artifacts_counts['HSTS'] = len(result_list)
         self.parsed_artifacts.extend(result_list)
+        return len(result_list)
 
     def resolve_kg_entities(self, api_key):
         """Resolve Knowledge Graph entity/category IDs to human-readable names via Google's KG API."""
@@ -4801,20 +4870,19 @@ class Chrome(WebBrowser):
                 driver.run(
                     'URL', 'History', self.get_history,
                     self.profile_path, 'History', self.version, 'url',
-                    display_key='History', display_value=f'URL records',
+                    display_value=f'URL records',
                     artifact='history')
 
                 driver.run(
                     'Download', 'History_downloads', self.get_downloads,
                     self.profile_path, 'History', self.version, 'download',
-                    display_key='History_downloads', display_value=f'Download records',
+                    display_value=f'Download records',
                     artifact='downloads')
 
             if 'shared_proto_db' in input_listing:
                 driver.run(
                     'Downloads (shared_proto_db)', 'shared_proto_db downloads',
                     self.get_shared_proto_db_downloads, self.profile_path, 'shared_proto_db',
-                    display_key='shared_proto_db downloads',
                     display_value='shared_proto_db download records',
                     artifact='downloads')
 
@@ -4822,49 +4890,49 @@ class Chrome(WebBrowser):
                 driver.run(
                     'Archived History', 'Archived History', self.get_history,
                     self.profile_path, 'Archived History', self.version, 'url (archived)',
-                    display_key='Archived History', display_value='Archived URL records',
+                    display_value='Archived URL records',
                     artifact='archived-history')
 
             if 'Media History' in input_listing:
                 driver.run(
                     'Media History', 'Media History', self.get_media_history,
                     self.profile_path, 'Media History', self.version, 'media (playback end)',
-                    display_key='Media History', display_value='Media History records',
+                    display_value='Media History records',
                     artifact='media-history')
 
             if 'Web Data' in input_listing:
                 driver.run(
                     'Autofill', 'Autofill', self.get_autofill,
                     self.profile_path, 'Web Data', self.version,
-                    display_key='Autofill', display_value='Autofill records',
+                    display_value='Autofill records',
                     artifact='autofill')
 
             if 'Login Data' in input_listing:
                 driver.run(
                     'Login Data', 'Login Data', self.get_login_data,
                     self.profile_path, 'Login Data', self.version,
-                    display_key='Login Data', display_value='Login Data records',
+                    display_value='Login Data records',
                     artifact='logins')
 
             if 'Login Data For Account' in input_listing:
                 driver.run(
                     'Login Data', 'Login Data', self.get_login_data,
                     self.profile_path, 'Login Data For Account', self.version,
-                    display_key='Login Data', display_value='Login Data (Account) records',
+                    display_value='Login Data (Account) records',
                     artifact='logins')
 
             if 'Bookmarks' in input_listing:
                 driver.run(
                     'Bookmarks', 'Bookmarks', self.get_bookmarks,
                     self.profile_path, 'Bookmarks', self.version,
-                    display_key='Bookmarks', display_value='Bookmark records',
+                    display_value='Bookmark records',
                     artifact='bookmarks')
 
             if 'Sessions' in input_listing:
                 driver.run(
                     'Sessions', 'Sessions', self.get_sessions,
                     self.profile_path, 'Sessions',
-                    display_key='Sessions', display_value='Session (SNSS) records',
+                    display_value='Session (SNSS) records',
                     artifact='sessions')
 
             # Website Storage
@@ -4873,14 +4941,14 @@ class Chrome(WebBrowser):
                 driver.run(
                     'Network Cookies', 'Cookies', self.get_cookies,
                     os.path.join(self.profile_path, 'Network'), 'Cookies', self.version,
-                    display_key='Cookies', display_value='Cookie records',
+                    display_value='Cookie records',
                     artifact='cookies')
 
             elif 'Cookies' in input_listing:
                 driver.run(
                     'Cookies', 'Cookies', self.get_cookies,
                     self.profile_path, 'Cookies', self.version,
-                    display_key='Cookies', display_value='Cookie records',
+                    display_value='Cookie records',
                     artifact='cookies')
 
             if self.cache_path is not None and self.cache_path != '':
@@ -4888,7 +4956,7 @@ class Chrome(WebBrowser):
                 driver.run(
                     'Cache', 'Cache', self.get_cache,
                     c_path, c_dir, row_type='cache',
-                    display_key='Cache', display_value='Cache records',
+                    display_value='Cache records',
                     artifact='cache')
 
             elif 'Cache' in input_listing:
@@ -4896,13 +4964,13 @@ class Chrome(WebBrowser):
                     driver.run(
                         'Cache', 'Cache', self.get_cache,
                         os.path.join(self.profile_path, 'Cache'), 'Cache_Data', row_type='cache',
-                        display_key='Cache', display_value='Cache records',
+                        display_value='Cache records',
                         artifact='cache')
                 else:
                     driver.run(
                         'Cache', 'Cache', self.get_cache,
                         self.profile_path, 'Cache', row_type='cache',
-                        display_key='Cache', display_value='Cache records',
+                        display_value='Cache records',
                         artifact='cache')
                 
             for cache_dir, cache_type, cache_artifact in SECONDARY_CACHE_DIRS:
@@ -4910,49 +4978,49 @@ class Chrome(WebBrowser):
                     driver.run(
                         cache_dir, cache_dir, self.get_cache,
                         self.profile_path, cache_dir, row_type=f'cache ({cache_type})',
-                        display_key=cache_dir, display_value=f'{cache_dir} records',
+                        display_value=f'{cache_dir} records',
                         artifact=cache_artifact)
 
             if 'Local Storage' in input_listing:
                 driver.run(
                     'Local Storage', 'Local Storage', self.get_local_storage,
                     self.profile_path, 'Local Storage',
-                    display_key='Local Storage', display_value='Local Storage records',
+                    display_value='Local Storage records',
                     artifact='local-storage')
 
             if 'Session Storage' in input_listing:
                 driver.run(
                     'Session Storage', 'Session Storage', self.get_session_storage,
                     self.profile_path, 'Session Storage',
-                    display_key='Session Storage', display_value='Session Storage records',
+                    display_value='Session Storage records',
                     artifact='session-storage')
 
             if 'IndexedDB' in input_listing:
                 driver.run(
                     'IndexedDB', 'IndexedDB', self.get_indexeddb,
                     self.profile_path, 'IndexedDB',
-                    display_key='IndexedDB', display_value='IndexedDB records',
+                    display_value='IndexedDB records',
                     artifact='indexeddb')
 
             if 'File System' in input_listing:
                 driver.run(
                     'File System', 'File System', self.get_file_system,
                     self.profile_path, 'File System',
-                    display_key='File System', display_value='File System items',
+                    display_value='File System items',
                     artifact='file-system')
 
             if 'Platform Notifications' in input_listing:
                 driver.run(
                     'Platform Notifications', 'Platform Notifications', self.get_platform_notifications,
                     self.profile_path, 'Platform Notifications',
-                    display_key='Platform Notifications', display_value='Platform Notification records',
+                    display_value='Platform Notification records',
                     artifact='notifications')
 
             if 'Service Worker' in input_listing:
                 driver.run(
                     'Service Workers', 'Service Workers', self.get_service_workers,
                     self.profile_path, 'Service Worker',
-                    display_key='Service Workers', display_value='Service Worker registrations',
+                    display_value='Service Worker registrations',
                     artifact='service-workers')
 
             # Browser Extensions
@@ -4962,14 +5030,14 @@ class Chrome(WebBrowser):
                 driver.run(
                     'Extensions', 'Extensions', self.get_extensions,
                     self.profile_path, 'Extensions',
-                    display_key='Extensions', display_value='Installed Extensions',
+                    display_value='Installed Extensions',
                     artifact='extensions')
 
             if 'Secure Preferences' in input_listing:
                 driver.run(
                     'Extension Settings', 'Secure Preferences', self.get_extension_settings,
                     self.profile_path, 'Secure Preferences',
-                    display_key='Extension Settings', display_value='Extension settings entries',
+                    display_value='Extension settings entries',
                     artifact='extension-settings')
 
             if 'Extension Cookies' in input_listing:
@@ -4984,7 +5052,7 @@ class Chrome(WebBrowser):
                 driver.run(
                     'Extension Cookies', 'Extension Cookies', self.get_cookies,
                     self.profile_path, 'Extension Cookies', ext_cookies_version,
-                    display_key='Extension Cookies', display_value='Extension Cookie records',
+                    display_value='Extension Cookie records',
                     artifact='extension-cookies')
 
             for directory in ['Extension Rules', 'Extension Scripts', 'Extension State']:
@@ -4992,14 +5060,14 @@ class Chrome(WebBrowser):
                     driver.run(
                         directory, directory, self.get_unified_extension_data,
                         self.profile_path, directory,
-                        display_key=f'{directory}', display_value=f'{directory} records',
+                        display_value=f'{directory} records',
                         artifact='extension-storage')
 
             if 'DNR Extension Rules' in input_listing:
                 driver.run(
                     'DNR Extension Rules', 'DNR Extension Rules', self.get_dnr_extension_rules,
                     self.profile_path, 'DNR Extension Rules',
-                    display_key='DNR Extension Rules', display_value='DNR Extension Rules records',
+                    display_value='DNR Extension Rules records',
                     artifact='dnr-rules')
 
             for directory in ['Local App Settings', 'Local Extension Settings',
@@ -5008,7 +5076,7 @@ class Chrome(WebBrowser):
                     driver.run(
                         directory, directory, self.get_partitioned_extension_data,
                         self.profile_path, directory,
-                        display_key=f'{directory}', display_value=f'{directory} records',
+                        display_value=f'{directory} records',
                         artifact='extension-storage')
 
             # Configuration & Supporting Data
@@ -5018,48 +5086,48 @@ class Chrome(WebBrowser):
                 driver.run(
                     'Preferences', 'Preferences', self.get_preferences,
                     self.profile_path, 'Preferences',
-                    display_key='Preferences', display_value='Preference items',
+                    display_value='Preference items',
                     artifact='preferences')
 
             if 'Site Characteristics Database' in input_listing:
                 driver.run(
                     'Site Characteristics', 'Site Characteristics', self.get_site_characteristics,
                     self.profile_path, 'Site Characteristics Database',
-                    display_key='Site Characteristics', display_value='Site Characteristics records',
+                    display_value='Site Characteristics records',
                     artifact='site-characteristics')
 
             if 'Sync Data' in input_listing:
                 driver.run(
                     'Sync Data', 'Sync Data', self.get_sync_data,
                     self.profile_path, 'Sync Data',
-                    display_key='Sync Data', display_value='Sync Data records',
+                    display_value='Sync Data records',
                     artifact='sync-data')
 
             if network_listing and 'TransportSecurity' in network_listing:
                 driver.run(
                     'Network HSTS', 'HSTS', self.get_transport_security,
                     os.path.join(self.profile_path, 'Network'), 'TransportSecurity',
-                    display_key='HSTS', display_value='HSTS records',
+                    display_value='HSTS records',
                     artifact='hsts')
 
             elif 'TransportSecurity' in input_listing:
                 driver.run(
                     'HSTS', 'HSTS', self.get_transport_security,
                     self.profile_path, 'TransportSecurity',
-                    display_key='HSTS', display_value='HSTS records',
+                    display_value='HSTS records',
                     artifact='hsts')
 
             if 'DIPS' in input_listing:
                 driver.run(
                     'DIPS Popups', 'DIPS Popups', self.get_dips_popups,
                     self.profile_path, 'DIPS', self.version,
-                    display_key='DIPS Popups', display_value='DIPS Popup records',
+                    display_value='DIPS Popup records',
                     artifact='dips')
 
                 driver.run(
                     'DIPS', 'DIPS', self.get_dips,
                     self.profile_path, 'DIPS', self.version,
-                    display_key='DIPS', display_value='DIPS records',
+                    display_value='DIPS records',
                     artifact='dips')
 
         # Destroy the cached key so that JSON serialization doesn't
@@ -5093,10 +5161,6 @@ class Chrome(WebBrowser):
 
         self.parsed_artifacts.sort(key=timeline_sort_key)
         self.parsed_storage.sort()
-
-        # Split parse failures out of the record counts now that the live display has
-        # finished reading them.
-        self.finalize_artifact_status()
 
         # Clean temp directory after processing profile
         if not self.no_copy:

--- a/pyhindsight/browsers/firefox.py
+++ b/pyhindsight/browsers/firefox.py
@@ -10,7 +10,8 @@ import struct
 import urllib.parse
 
 from pyhindsight import utils
-from pyhindsight.browsers.webbrowser import WebBrowser, timeline_sort_key
+from pyhindsight.browsers.webbrowser import (
+    ParseFailures, WebBrowser, timeline_sort_key)
 
 log = logging.getLogger(__name__)
 
@@ -148,24 +149,15 @@ class Firefox(WebBrowser):
         if self.structure is None:
             self.structure = {}
 
-    def _open(self, path, database, count_key):
-        """Open a profile database, recording a failure under `count_key`.
+    def _open(self, path, database):
+        """Open a profile database, returning None if it could not be opened.
 
-        `count_key` must be the same `artifacts_counts` key this caller reports its
-        record count under -- not the filename, unless they happen to match. The live
-        display and the run's status summary look the artifact up by that key, so a
-        failure filed under the filename is invisible to both: the display falls back to
-        "0", which reads as "parsed fine, found nothing" rather than "could not read".
-
-        Pass `count_key=None` for a probe that is not an artifact parse (version
-        detection), so a failed probe doesn't mark an artifact as failed.
+        Callers translate None into their own ``return None``, which the driver records
+        as a failed parse for whichever artifact the caller was invoked for. The helper
+        deliberately doesn't report anything itself: it has no idea which artifact its
+        caller is parsing.
         """
-        conn = utils.open_sqlite_db(self, path, database)
-        if not conn:
-            if count_key is not None:
-                self.artifacts_counts[count_key] = 'Failed'
-            return None
-        return conn
+        return utils.open_sqlite_db(self, path, database) or None
 
     @staticmethod
     def _visit_type_friendly(visit_type):
@@ -175,9 +167,9 @@ class Firefox(WebBrowser):
 
     def determine_version(self, path, database='places.sqlite'):
         # places.sqlite tracks schema with PRAGMA user_version; Firefox 62+ is >= 52.
-        conn = self._open(path, database, count_key=None)
+        conn = self._open(path, database)
         if not conn:
-            return
+            return None
         try:
             cursor = conn.cursor()
             cursor.execute('PRAGMA user_version')
@@ -218,9 +210,9 @@ class Firefox(WebBrowser):
         results = []
         log.info(f'History items from {database}:')
 
-        conn = self._open(path, database, count_key=database)
+        conn = self._open(path, database)
         if not conn:
-            return
+            return None
 
         # `description` and `preview_image_url` were added to moz_places in
         # MigrateV38Up (places schema v38 / Firefox 57). Profiles below that — e.g.
@@ -263,8 +255,7 @@ class Firefox(WebBrowser):
             cursor = conn.cursor()
             if not self._execute_versioned_query(cursor, queries, 'history'):
                 log.error(' - Could not query history with any known schema')
-                self.artifacts_counts[database] = 'Failed'
-                return
+                return None
 
             source_item = os.path.relpath(os.path.join(path, database), self.profile_path)
             for row in cursor:
@@ -294,9 +285,8 @@ class Firefox(WebBrowser):
                     new_row.interpretation = f'Referrer: {from_url}'
                 results.append(new_row)
 
-            self.artifacts_counts[database] = len(results)
-            log.info(f' - Parsed {len(results)} items')
             self.parsed_artifacts.extend(results)
+            return len(results)
         finally:
             conn.close()
 
@@ -305,9 +295,9 @@ class Firefox(WebBrowser):
         results = []
         log.info(f'Bookmark items from {database}:')
 
-        conn = self._open(path, database, count_key='Bookmarks')
+        conn = self._open(path, database)
         if not conn:
-            return
+            return None
 
         try:
             cursor = conn.cursor()
@@ -352,9 +342,8 @@ class Firefox(WebBrowser):
                     item.source_item = source_item
                     results.append(item)
 
-            self.artifacts_counts['Bookmarks'] = len(results)
-            log.info(f' - Parsed {len(results)} items')
             self.parsed_artifacts.extend(results)
+            return len(results)
         finally:
             conn.close()
 
@@ -364,9 +353,9 @@ class Firefox(WebBrowser):
         results = []
         log.info(f'Cookie items from {database}:')
 
-        conn = self._open(path, database, count_key='Cookies')
+        conn = self._open(path, database)
         if not conn:
-            return
+            return None
 
         try:
             cursor = conn.cursor()
@@ -378,8 +367,7 @@ class Firefox(WebBrowser):
                 )
             except Exception as e:
                 log.error(f' - Could not query cookies: {e}')
-                self.artifacts_counts['Cookies'] = 'Failed'
-                return
+                return None
 
             source_item = os.path.relpath(os.path.join(path, database), self.profile_path)
             zero_ts = datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
@@ -427,9 +415,8 @@ class Firefox(WebBrowser):
                     accessed_row.timestamp = accessed
                     results.append(accessed_row)
 
-            self.artifacts_counts['Cookies'] = len(results)
-            log.info(f' - Parsed {len(results)} items')
             self.parsed_artifacts.extend(results)
+            return len(results)
         finally:
             conn.close()
 
@@ -439,9 +426,9 @@ class Firefox(WebBrowser):
         results = []
         log.info(f'Download items from {database}:')
 
-        conn = self._open(path, database, count_key=database + '_downloads')
+        conn = self._open(path, database)
         if not conn:
-            return
+            return None
 
         try:
             cursor = conn.cursor()
@@ -456,8 +443,7 @@ class Firefox(WebBrowser):
                 )
             except Exception as e:
                 log.error(f' - Could not query downloads: {e}')
-                self.artifacts_counts[database + '_downloads'] = 'Failed'
-                return
+                return None
 
             source_item = os.path.relpath(os.path.join(path, database), self.profile_path)
             for row in cursor:
@@ -493,9 +479,8 @@ class Firefox(WebBrowser):
                 item.source_item = source_item
                 results.append(item)
 
-            self.artifacts_counts[database + '_downloads'] = len(results)
-            log.info(f' - Parsed {len(results)} items')
             self.parsed_artifacts.extend(results)
+            return len(results)
         finally:
             conn.close()
 
@@ -505,9 +490,9 @@ class Firefox(WebBrowser):
         results = []
         log.info(f'Form history items from {database}:')
 
-        conn = self._open(path, database, count_key=database)
+        conn = self._open(path, database)
         if not conn:
-            return
+            return None
 
         try:
             cursor = conn.cursor()
@@ -529,8 +514,7 @@ class Firefox(WebBrowser):
                     cursor.execute("SELECT fieldname, value FROM moz_formhistory")
             except Exception as e:
                 log.error(f' - Could not query form history: {e}')
-                self.artifacts_counts[database] = 'Failed'
-                return
+                return None
 
             source_item = os.path.relpath(os.path.join(path, database), self.profile_path)
             for row in cursor:
@@ -562,10 +546,8 @@ class Firefox(WebBrowser):
                 item.source_item = source_item
                 results.append(item)
 
-            self.artifacts_counts[database] = len(results)
-            self.artifacts_display['Autofill'] = 'Form history records'
-            log.info(f' - Parsed {len(results)} items')
             self.parsed_artifacts.extend(results)
+            return len(results)
         finally:
             conn.close()
 
@@ -590,9 +572,9 @@ class Firefox(WebBrowser):
         results = []
         log.info(f'Permissions items from {database}:')
 
-        conn = self._open(path, database, count_key='Permissions')
+        conn = self._open(path, database)
         if not conn:
-            return
+            return None
 
         try:
             cursor = conn.cursor()
@@ -604,8 +586,7 @@ class Firefox(WebBrowser):
                 )
             except Exception as e:
                 log.error(f' - Could not query permissions: {e}')
-                self.artifacts_counts['Permissions'] = 'Failed'
-                return
+                return None
 
             source_item = os.path.relpath(os.path.join(path, database), self.profile_path)
             for row in cursor:
@@ -640,9 +621,8 @@ class Firefox(WebBrowser):
                 item.value = perm_label
                 results.append(item)
 
-            self.artifacts_counts['Permissions'] = len(results)
-            log.info(f' - Parsed {len(results)} items')
             self.parsed_artifacts.extend(results)
+            return len(results)
         finally:
             conn.close()
 
@@ -661,15 +641,14 @@ class Firefox(WebBrowser):
         log.info(f'HSTS items from {filename}:')
         if not os.path.isfile(full_path):
             log.info(f' - {full_path} not present')
-            return
+            return 0
 
         try:
             with open(full_path, 'rb') as fh:
                 blob = fh.read()
         except OSError as e:
             log.error(f' - Could not read {full_path}: {e}')
-            self.artifacts_counts['HSTS'] = 'Failed'
-            return
+            return None
 
         source_item = os.path.relpath(full_path, self.profile_path)
         n_records = len(blob) // self._HSTS_RECORD_SIZE
@@ -743,9 +722,8 @@ class Firefox(WebBrowser):
             item.source_item = source_item
             results.append(item)
 
-        self.artifacts_counts['HSTS'] = len(results)
-        log.info(f' - Parsed {len(results)} items')
         self.parsed_artifacts.extend(results)
+        return len(results)
 
     @staticmethod
     def _parse_prefs_value(raw):
@@ -767,7 +745,7 @@ class Firefox(WebBrowser):
         log.info(f'Preferences from {prefs_file}:')
         if not os.path.isfile(full_path):
             log.info(f' - {full_path} not present')
-            return
+            return 0
 
         all_prefs = {}
         try:
@@ -784,8 +762,7 @@ class Firefox(WebBrowser):
                     all_prefs[name] = value
         except OSError as e:
             log.error(f' - Could not read {full_path}: {e}')
-            self.artifacts_counts['Preferences'] = 'Failed'
-            return
+            return None
 
         results = []
         seen = set()
@@ -826,7 +803,6 @@ class Firefox(WebBrowser):
                 })
 
         pref_count = sum(1 for r in results if r['name'] is not None)
-        self.artifacts_counts['Preferences'] = pref_count
 
         profile_folder = os.path.basename(path.rstrip(os.sep)) or 'profile'
         presentation = {
@@ -840,6 +816,7 @@ class Firefox(WebBrowser):
         }
         self.preferences.append({'data': results, 'presentation': presentation})
         log.info(f' - Parsed {pref_count} preferences')
+        return pref_count
 
     def get_logins(self, path, filename='logins.json'):
         # Username and password values are NSS/3DES-CBC encrypted (key wrapped in key4.db).
@@ -849,15 +826,14 @@ class Firefox(WebBrowser):
         log.info(f'Saved logins from {filename}:')
         if not os.path.isfile(full_path):
             log.info(f' - {full_path} not present')
-            return
+            return 0
 
         try:
             with open(full_path, 'r', encoding='utf-8', errors='replace') as fh:
                 data = json.load(fh)
         except (OSError, json.JSONDecodeError) as e:
             log.error(f' - Could not read {full_path}: {e}')
-            self.artifacts_counts['Logins'] = 'Failed'
-            return
+            return None
 
         source_item = os.path.relpath(full_path, self.profile_path)
         zero_ts = datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
@@ -937,9 +913,8 @@ class Firefox(WebBrowser):
             item.source_item = source_item
             results.append(item)
 
-        self.artifacts_counts['Logins'] = len(results)
-        log.info(f' - Parsed {len(results)} items')
         self.parsed_artifacts.extend(results)
+        return len(results)
 
     @staticmethod
     def _snappy_decompress(src):
@@ -1082,15 +1057,14 @@ class Firefox(WebBrowser):
         log.info(f'Installed extensions from {filename}:')
         if not os.path.isfile(full_path):
             log.info(f' - {full_path} not present')
-            return
+            return 0
 
         try:
             with open(full_path, 'r', encoding='utf-8', errors='replace') as fh:
                 data = json.load(fh)
         except (OSError, json.JSONDecodeError) as e:
             log.error(f' - Could not read {full_path}: {e}')
-            self.artifacts_counts['Extensions'] = 'Failed'
-            return
+            return None
 
         results = []
         for addon in data.get('addons', []):
@@ -1148,8 +1122,6 @@ class Firefox(WebBrowser):
                 manifest=json.dumps(manifest_summary),
             ))
 
-        self.artifacts_counts['Extensions'] = len(results)
-        log.info(f' - Parsed {len(results)} items')
 
         presentation = {
             'title': 'Installed Extensions',
@@ -1164,6 +1136,7 @@ class Firefox(WebBrowser):
             ],
         }
         self.installed_extensions = {'data': results, 'presentation': presentation}
+        return len(results)
 
     # Firefox 'sizemode' -> the Chrome-style window state labels the Sessions sheet uses.
     SESSIONSTORE_SIZEMODES = {
@@ -1381,6 +1354,7 @@ class Firefox(WebBrowser):
         # (previous live), previous.jsonlz4 (last clean close), upgrade.jsonlz4-<ts>
         # (per-upgrade snapshot, often preserves state from older Firefox versions).
         results = []
+        unparsed = ParseFailures('Sessions')
         log.info('Sessionstore items:')
 
         candidates = []
@@ -1401,7 +1375,7 @@ class Firefox(WebBrowser):
 
         if not candidates:
             log.info(' - No sessionstore files found')
-            return
+            return 0
 
         # Snapshots overlap heavily, so every window is merged into one structure keyed
         # by content; seen_windows maps a layout signature to the window that owns it.
@@ -1419,7 +1393,7 @@ class Firefox(WebBrowser):
                     continue
                 doc = json.loads(raw)
             except (json.JSONDecodeError, UnicodeDecodeError) as e:
-                log.warning(f' - Could not parse {full_path}: {e}')
+                unparsed.source(full_path, f'could not be parsed ({e})')
                 continue
             source_item = os.path.relpath(full_path, self.profile_path)
             before = structure['entries_seen']
@@ -1449,12 +1423,12 @@ class Firefox(WebBrowser):
         # Most navigation entries have no timestamp of their own and are rendered on the
         # Sessions sheet only, so count what was parsed rather than what reached the
         # Timeline.
-        self.artifacts_counts['Sessions'] = entries_seen
         log.info(f' - Parsed {entries_seen} entries from {len(candidates)} snapshot(s) '
                  f'into {len(structure["windows"])} distinct window(s); '
                  f'{len(deduped)} timeline row(s) after collapsing '
                  f'{len(results) - len(deduped)} duplicate(s)')
         self.parsed_artifacts.extend(deduped)
+        return unparsed.result(entries_seen)
 
     def get_bookmark_backups(self, path):
         # Firefox writes a fresh jsonlz4 snapshot of the bookmark tree daily and
@@ -1463,10 +1437,11 @@ class Firefox(WebBrowser):
         log.info('Bookmark backups:')
         if not os.path.isdir(backups_dir):
             log.info(f' - {backups_dir} not present')
-            return
+            return 0
 
         zero_ts = datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
         results = []
+        unparsed = ParseFailures('Bookmark Backups')
 
         def _walk(node, parent_title, snapshot_label, source_item):
             type_code = node.get('typeCode')
@@ -1521,7 +1496,7 @@ class Firefox(WebBrowser):
                     with open(full, 'r', encoding='utf-8', errors='replace') as fh:
                         doc = json.load(fh)
             except (json.JSONDecodeError, OSError) as e:
-                log.warning(f' - Could not parse {full}: {e}')
+                unparsed.source(full, f'could not be parsed ({e})')
                 continue
             source_item = os.path.relpath(full, self.profile_path)
             before = len(results)
@@ -1529,9 +1504,9 @@ class Firefox(WebBrowser):
                 _walk(child, '', name, source_item)
             log.info(f' - {name}: {len(results) - before} entries')
 
-        self.artifacts_counts['Bookmark Backups'] = len(results)
         log.info(f' - Parsed {len(results)} items total')
         self.parsed_artifacts.extend(results)
+        return unparsed.result(len(results))
 
     def get_favicons(self, path, database='favicons.sqlite'):
         # favicons.sqlite survives 'Clear History' on places.sqlite, so pages
@@ -1539,9 +1514,9 @@ class Firefox(WebBrowser):
         results = []
         log.info(f'Favicon items from {database}:')
 
-        conn = self._open(path, database, count_key='Favicons')
+        conn = self._open(path, database)
         if not conn:
-            return
+            return None
 
         try:
             cursor = conn.cursor()
@@ -1554,8 +1529,7 @@ class Firefox(WebBrowser):
                 )
             except Exception as e:
                 log.error(f' - Could not query favicons: {e}')
-                self.artifacts_counts['Favicons'] = 'Failed'
-                return
+                return None
 
             source_item = os.path.relpath(os.path.join(path, database), self.profile_path)
             zero_ts = datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
@@ -1596,9 +1570,8 @@ class Firefox(WebBrowser):
                 item.source_item = source_item
                 results.append(item)
 
-            self.artifacts_counts['Favicons'] = len(results)
-            log.info(f' - Parsed {len(results)} items')
             self.parsed_artifacts.extend(results)
+            return len(results)
         finally:
             conn.close()
 
@@ -1621,9 +1594,9 @@ class Firefox(WebBrowser):
         results = []
         log.info(f'Bounce tracking items from {database}:')
 
-        conn = self._open(path, database, count_key='Bounce Tracking')
+        conn = self._open(path, database)
         if not conn:
-            return
+            return None
 
         try:
             cursor = conn.cursor()
@@ -1634,8 +1607,7 @@ class Firefox(WebBrowser):
                 )
             except Exception as e:
                 log.error(f' - Could not query bounce-tracking state: {e}')
-                self.artifacts_counts['Bounce Tracking'] = 'Failed'
-                return
+                return None
 
             source_item = os.path.relpath(os.path.join(path, database), self.profile_path)
             for row in cursor:
@@ -1662,9 +1634,8 @@ class Firefox(WebBrowser):
                 item.source_item = source_item
                 results.append(item)
 
-            self.artifacts_counts['Bounce Tracking'] = len(results)
-            log.info(f' - Parsed {len(results)} items')
             self.parsed_artifacts.extend(results)
+            return len(results)
         finally:
             conn.close()
 
@@ -1673,9 +1644,9 @@ class Firefox(WebBrowser):
         results = []
         log.info(f'Content-blocking items from {database}:')
 
-        conn = self._open(path, database, count_key='Content Blocking')
+        conn = self._open(path, database)
         if not conn:
-            return
+            return None
 
         try:
             cursor = conn.cursor()
@@ -1683,8 +1654,7 @@ class Firefox(WebBrowser):
                 cursor.execute("SELECT type, count, timestamp FROM events")
             except Exception as e:
                 log.error(f' - Could not query content-blocking events: {e}')
-                self.artifacts_counts['Content Blocking'] = 'Failed'
-                return
+                return None
 
             source_item = os.path.relpath(os.path.join(path, database), self.profile_path)
             for row in cursor:
@@ -1717,9 +1687,8 @@ class Firefox(WebBrowser):
                 item.source_item = source_item
                 results.append(item)
 
-            self.artifacts_counts['Content Blocking'] = len(results)
-            log.info(f' - Parsed {len(results)} items')
             self.parsed_artifacts.extend(results)
+            return len(results)
         finally:
             conn.close()
 
@@ -2093,8 +2062,7 @@ class Firefox(WebBrowser):
             names = os.listdir(cache_entries_dir)
         except OSError as e:
             log.error(f' - Could not read cache directory: {e}')
-            self.artifacts_counts['Cache'] = 'Failed'
-            return
+            return None
 
         source_item = os.path.relpath(cache_entries_dir, self.profile_path) \
             if cache_entries_dir.startswith(self.profile_path) else cache_entries_dir
@@ -2187,11 +2155,9 @@ class Firefox(WebBrowser):
                     f'{n} {state}' for state, n in
                     sorted(recovery_counts.items(), key=lambda kv: -kv[1]))
                 log.info(f'   - Recovery breakdown: {breakdown}')
-        else:
-            log.info(f' - Parsed {len(results)} items')
 
-        self.artifacts_counts['Cache'] = len(results)
         self.parsed_artifacts.extend(results)
+        return len(results)
 
     @staticmethod
     def _decode_origin_folder(name):
@@ -2228,12 +2194,12 @@ class Firefox(WebBrowser):
         log.info(f'localStorage from {storage_root}:')
         if not os.path.isdir(storage_root):
             log.info(' - storage/default not present')
-            return
+            return 0
 
         results = []
+        unparsed = ParseFailures('Local Storage')
         origins_seen = 0
         origins_with_data = 0
-        decode_failures = 0
 
         for origin_folder in sorted(os.listdir(storage_root)):
             ls_dir = os.path.join(storage_root, origin_folder, 'ls')
@@ -2244,6 +2210,8 @@ class Firefox(WebBrowser):
 
             conn = utils.open_sqlite_db(self, ls_dir, 'data.sqlite')
             if not conn:
+                unparsed.source(f'{origin_folder}/ls/data.sqlite',
+                              self.describe_open_failure())
                 continue
 
             try:
@@ -2264,7 +2232,8 @@ class Firefox(WebBrowser):
                         "FROM data"
                     )
                 except Exception as e:
-                    log.debug(f' - {origin_folder}: data table unreadable ({e})')
+                    unparsed.source(f'{origin_folder}/ls/data.sqlite',
+                                  f'data table unreadable ({e})')
                     continue
 
                 source_path = os.path.relpath(ls_db, self.profile_path)
@@ -2276,9 +2245,9 @@ class Firefox(WebBrowser):
                     except StopIteration:
                         break
                     except Exception as e:
-                        log.warning(
-                            f' - {origin_folder}: localStorage db unreadable, '
-                            f'skipping remaining rows ({e})')
+                        unparsed.source(f'{origin_folder}/ls/data.sqlite',
+                                      f'unreadable partway through; remaining rows '
+                                      f'not enumerated ({e})')
                         break
                     key = row.get('key') or ''
                     conv = row.get('conversion_type') or 0
@@ -2288,8 +2257,7 @@ class Firefox(WebBrowser):
                         value = self._decode_ls_value(
                             raw_value, conv, comp, source_path)
                     except Exception as e:
-                        log.debug(f' - decode failed in {origin_folder}/{key}: {e}')
-                        decode_failures += 1
+                        unparsed.record(f'{origin_folder}/{key}', f'decode failed ({e})')
                         continue
 
                     last_access_raw = row.get('last_access_time') or 0
@@ -2325,19 +2293,12 @@ class Firefox(WebBrowser):
             finally:
                 conn.close()
 
-        self.artifacts_counts['Local Storage'] = len(results)
-        if decode_failures:
-            log.info(
-                f' - Parsed {len(results)} records from {origins_with_data} '
-                f'origins ({origins_seen} scanned, {decode_failures} decode '
-                f'failures)'
-            )
-        else:
-            log.info(
-                f' - Parsed {len(results)} records from {origins_with_data} '
-                f'origins ({origins_seen} scanned)'
-            )
+        log.info(
+            f' - Parsed {len(results)} records from {origins_with_data} '
+            f'origins ({origins_seen} scanned)'
+        )
         self.parsed_storage.extend(results)
+        return unparsed.result(len(results))
 
     # SCTAG values from mozilla-central/js/src/vm/StructuredClone.cpp StructuredDataType.
     # Tags below SCTAG_HEADER (0xFFF10000) are doubles encoded as their 64-bit IEEE bits.
@@ -2654,9 +2615,10 @@ class Firefox(WebBrowser):
         log.info(f'IndexedDB from {storage_root}:')
         if not os.path.isdir(storage_root):
             log.info(' - storage/default not present')
-            return
+            return 0
 
         results = []
+        unparsed = ParseFailures('IndexedDB')
         idb_files_seen = 0
         idb_files_with_data = 0
         decode_failures = 0
@@ -2673,6 +2635,7 @@ class Firefox(WebBrowser):
 
                 conn = utils.open_sqlite_db(self, idb_dir, db_filename)
                 if not conn:
+                    unparsed.source(db_filename, self.describe_open_failure())
                     continue
 
                 try:
@@ -2703,7 +2666,7 @@ class Firefox(WebBrowser):
                         cursor.execute(
                             'SELECT object_store_id, key, data FROM object_data')
                     except Exception as e:
-                        log.debug(f' - {db_filename}: object_data unreadable ({e})')
+                        unparsed.source(db_filename, f'object_data unreadable ({e})')
                         continue
 
                     source_path = os.path.relpath(
@@ -2728,6 +2691,8 @@ class Firefox(WebBrowser):
                                 value_str = self._stringify_idb_value(value_obj)
                             except Exception as e:
                                 decode_failures += 1
+                                unparsed.record(f'{db_filename}:{key_str}',
+                                              f'value decode failed ({e})')
                                 value_str = f'<decode failed: {e}>'
                         else:
                             empty_blobs += 1
@@ -2749,13 +2714,13 @@ class Firefox(WebBrowser):
                 finally:
                     conn.close()
 
-        self.artifacts_counts['IndexedDB'] = len(results)
         log.info(
             f' - Parsed {len(results)} records from {idb_files_with_data} '
             f'IndexedDB files ({idb_files_seen} scanned, '
             f'{decode_failures} decode failures, {empty_blobs} empty blobs)'
         )
         self.parsed_storage.extend(results)
+        return unparsed.result(len(results))
 
     def get_cache_storage(self, path):
         # Cache API (JS-visible, used by Service Workers) is distinct from cache2.
@@ -2765,9 +2730,10 @@ class Firefox(WebBrowser):
         log.info(f'Cache API storage from {storage_root}:')
         if not os.path.isdir(storage_root):
             log.info(' - storage/default not present')
-            return
+            return 0
 
         results = []
+        unparsed = ParseFailures('Cache API')
         origins_seen = 0
         origins_with_data = 0
         missing_bodies = 0
@@ -2782,6 +2748,8 @@ class Firefox(WebBrowser):
 
             conn = utils.open_sqlite_db(self, cache_dir, 'caches.sqlite')
             if not conn:
+                unparsed.source(f'{origin_folder}/cache/caches.sqlite',
+                              self.describe_open_failure())
                 continue
 
             try:
@@ -2828,7 +2796,8 @@ class Firefox(WebBrowser):
                         'FROM entries'
                     )
                 except Exception as e:
-                    log.debug(f' - {origin_folder}: entries unreadable ({e})')
+                    unparsed.source(f'{origin_folder}/cache/caches.sqlite',
+                                  f'entries unreadable ({e})')
                     continue
 
                 source_item = os.path.relpath(db_file, self.profile_path)
@@ -2931,13 +2900,13 @@ class Firefox(WebBrowser):
             finally:
                 conn.close()
 
-        self.artifacts_counts['Cache API'] = len(results)
         log.info(
             f' - Parsed {len(results)} entries from {origins_with_data} '
             f'origins ({origins_seen} scanned, {missing_bodies} bodies '
             f'missing from morgue)'
         )
         self.parsed_artifacts.extend(results)
+        return unparsed.result(len(results))
 
     def process(self):
         try:
@@ -2967,47 +2936,47 @@ class Firefox(WebBrowser):
                 driver.run(
                     'URL records', 'places.sqlite', self.get_history,
                     self.profile_path, 'places.sqlite',
-                    display_key='places.sqlite', display_value='URL records',
+                    display_value='URL records',
                     artifact='history')
 
                 driver.run(
                     'Download records', 'places.sqlite_downloads', self.get_downloads,
                     self.profile_path, 'places.sqlite',
-                    display_key='places.sqlite_downloads', display_value='Download records',
+                    display_value='Download records',
                     artifact='downloads')
 
                 driver.run(
                     'Bookmark records', 'Bookmarks', self.get_bookmarks,
                     self.profile_path, 'places.sqlite',
-                    display_key='Bookmarks', display_value='Bookmark records',
+                    display_value='Bookmark records',
                     artifact='bookmarks')
 
             if 'formhistory.sqlite' in input_listing:
                 driver.run(
                     'Form history records', 'formhistory.sqlite', self.get_form_history,
                     self.profile_path, 'formhistory.sqlite',
-                    display_key='formhistory.sqlite', display_value='Form history records',
+                    display_value='Form history records',
                     artifact='autofill')
 
             if 'sessionstore.jsonlz4' in input_listing or 'sessionstore-backups' in input_listing:
                 driver.run(
                     'Session (tab) records', 'Sessions', self.get_sessionstore,
                     self.profile_path,
-                    display_key='Sessions', display_value='Session (tab) records',
+                    display_value='Session (tab) records',
                     artifact='sessions')
 
             if 'bookmarkbackups' in input_listing:
                 driver.run(
                     'Bookmark backup records', 'Bookmark Backups', self.get_bookmark_backups,
                     self.profile_path,
-                    display_key='Bookmark Backups', display_value='Bookmark backup records',
+                    display_value='Bookmark backup records',
                     artifact='bookmark-backups')
 
             if 'favicons.sqlite' in input_listing:
                 driver.run(
                     'Favicon-derived URL records', 'Favicons', self.get_favicons,
                     self.profile_path, 'favicons.sqlite',
-                    display_key='Favicons', display_value='Favicon-derived URL records',
+                    display_value='Favicon-derived URL records',
                     artifact='favicons')
 
             # Website Storage
@@ -3016,7 +2985,7 @@ class Firefox(WebBrowser):
                 driver.run(
                     'Cookie records', 'Cookies', self.get_cookies,
                     self.profile_path, 'cookies.sqlite',
-                    display_key='Cookies', display_value='Cookie records',
+                    display_value='Cookie records',
                     artifact='cookies')
 
             if 'storage' in input_listing and os.path.isdir(
@@ -3024,19 +2993,19 @@ class Firefox(WebBrowser):
                 driver.run(
                     'Local Storage records', 'Local Storage', self.get_local_storage,
                     self.profile_path,
-                    display_key='Local Storage', display_value='Local Storage records',
+                    display_value='Local Storage records',
                     artifact='local-storage')
 
                 driver.run(
                     'IndexedDB records', 'IndexedDB', self.get_indexeddb,
                     self.profile_path,
-                    display_key='IndexedDB', display_value='IndexedDB records',
+                    display_value='IndexedDB records',
                     artifact='indexeddb')
 
                 driver.run(
                     'Cache API records', 'Cache API', self.get_cache_storage,
                     self.profile_path,
-                    display_key='Cache API', display_value='Cache API records',
+                    display_value='Cache API records',
                     artifact='cache-api')
 
             cache_dir = self._resolve_cache_dir()
@@ -3044,7 +3013,7 @@ class Firefox(WebBrowser):
                 driver.run(
                     'Cache records', 'Cache', self.get_cache,
                     cache_dir,
-                    display_key='Cache', display_value='Cache records',
+                    display_value='Cache records',
                     artifact='cache')
             else:
                 log.info('No Firefox cache2 directory found; skipping cache parse.')
@@ -3055,7 +3024,7 @@ class Firefox(WebBrowser):
                 driver.run(
                     'Installed Extensions', 'Extensions', self.get_extensions,
                     self.profile_path, 'extensions.json',
-                    display_key='Extensions', display_value='Installed Extensions',
+                    display_value='Installed Extensions',
                     artifact='extensions')
 
             # Configuration & Supporting Data
@@ -3064,49 +3033,45 @@ class Firefox(WebBrowser):
                 driver.run(
                     'Preference items', 'Preferences', self.get_preferences,
                     self.profile_path, 'prefs.js',
-                    display_key='Preferences', display_value='Preference items',
+                    display_value='Preference items',
                     artifact='preferences')
 
             if 'permissions.sqlite' in input_listing:
                 driver.run(
                     'Permission records', 'Permissions', self.get_permissions,
                     self.profile_path, 'permissions.sqlite',
-                    display_key='Permissions', display_value='Permission records',
+                    display_value='Permission records',
                     artifact='permissions')
 
             if 'SiteSecurityServiceState.bin' in input_listing:
                 driver.run(
                     'HSTS records', 'HSTS', self.get_hsts,
                     self.profile_path, 'SiteSecurityServiceState.bin',
-                    display_key='HSTS', display_value='HSTS records',
+                    display_value='HSTS records',
                     artifact='hsts')
 
             if 'logins.json' in input_listing:
                 driver.run(
                     'Saved login records', 'Logins', self.get_logins,
                     self.profile_path, 'logins.json',
-                    display_key='Logins', display_value='Saved login records',
+                    display_value='Saved login records',
                     artifact='logins')
 
             if 'bounce-tracking-protection.sqlite' in input_listing:
                 driver.run(
                     'Bounce-tracking records', 'Bounce Tracking', self.get_bounce_tracking,
                     self.profile_path, 'bounce-tracking-protection.sqlite',
-                    display_key='Bounce Tracking', display_value='Bounce-tracking records',
+                    display_value='Bounce-tracking records',
                     artifact='bounce-tracking')
 
             if 'protections.sqlite' in input_listing:
                 driver.run(
                     'Content-blocking event records', 'Content Blocking', self.get_content_blocking,
                     self.profile_path, 'protections.sqlite',
-                    display_key='Content Blocking', display_value='Content-blocking event records',
+                    display_value='Content-blocking event records',
                     artifact='content-blocking')
 
         self.parsed_artifacts.sort(key=timeline_sort_key)
-
-        # Split parse failures out of the record counts now that the live display has
-        # finished reading them.
-        self.finalize_artifact_status()
 
     class URLItem(WebBrowser.URLItem):
         pass

--- a/pyhindsight/browsers/webbrowser.py
+++ b/pyhindsight/browsers/webbrowser.py
@@ -1,9 +1,11 @@
 import abc
+import dataclasses
 import datetime
 import hashlib
 import logging
 import sqlite3
 import sys
+import typing
 import urllib.parse
 import rich.align
 import rich.columns
@@ -18,11 +20,148 @@ from pyhindsight.artifact_filter import ArtifactFilter
 
 log = logging.getLogger(__name__)
 
-# Per-artifact outcomes that are not record counts. These live in `artifacts_status`
-# rather than `artifacts_counts` so that a count is always a count: "couldn't read this"
-# and "read it, found nothing" have to stay distinguishable in output.
+# Per-artifact outcomes that are not record counts. A count is always a count:
+# "couldn't read this" and "read it, found nothing" have to stay distinguishable.
 ARTIFACT_STATUS_FAILED = 'failed'
 ARTIFACT_STATUS_SKIPPED = 'skipped'
+ARTIFACT_STATUS_PARTIAL = 'partial'
+
+# Marks a row whose parser is still running, so the table renders a spinner for it.
+_SPINNER = object()
+
+# Every collection a parser can deliver results into. The driver snapshots their sizes
+# around each parser so it can catch the one failure a count cannot reveal on its own:
+# results parsed and counted, then dropped before they reach any of these.
+RESULT_COLLECTIONS = (
+    'parsed_artifacts',
+    'parsed_storage',
+    'parsed_extension_data',
+    'parsed_sync_data',
+    'preferences',
+    'installed_extensions',
+    '_extensions_by_id',
+    'session_structure',
+)
+
+
+
+class ParseResult(typing.NamedTuple):
+    """What a parser produced, when some of it could not be read.
+
+    Failures come at two levels, and they are not interchangeable:
+
+    * **records** -- the source was opened and enumerated, and individual items in it
+      could not be decoded. Coverage is known and the loss is bounded: "900 entries,
+      5 of them corrupt".
+    * **sources** -- a whole store, database, origin folder, or file could not be
+      opened at all. Coverage is *unknown* and the loss is unbounded: the source might
+      have held nothing or a hundred thousand records, and there is no way to tell.
+
+    That asymmetry is why they are counted separately. A count with unparsed sources
+    behind it cannot be used to say "the profile contained N of these", which is
+    exactly the kind of claim a report should not make by accident.
+    """
+
+    count: int
+    unparsed_sources: int = 0
+    unparsed_records: int = 0
+
+    @property
+    def is_partial(self):
+        return bool(self.unparsed_sources or self.unparsed_records)
+
+
+class ParseFailures:
+    """Collects a parser's unparsed sources and records, logging each as it happens.
+
+    A parser that swallows an exception to keep going should record it here instead of
+    only logging it, so what the run reports and what the log explains cannot drift.
+    The per-failure detail is written at the moment of failure (naming the source and
+    the reason); the *totals* are logged by the driver from the recorded result, so the
+    numbers in the log are by construction the numbers on screen.
+    """
+
+    def __init__(self, artifact_label):
+        self.artifact_label = artifact_label
+        self.sources = []
+        self.records = []
+        self._seen = set()
+
+    def _note(self, bucket, name, reason):
+        """Add (name, reason) once. Re-reporting the same failure would inflate the
+        totals: some parsers read a file in more than one pass, and a file that is
+        truncated fails identically in each of them -- that is one unparsed source, not
+        one per pass."""
+        entry = (str(name), str(reason))
+        if entry in self._seen:
+            return False
+        self._seen.add(entry)
+        bucket.append(entry)
+        return True
+
+    def source(self, name, reason):
+        """Record a store/database/origin/file that could not be read at all."""
+        if self._note(self.sources, name, reason):
+            log.warning(f' - Unparsed source in {self.artifact_label}: {name} ({reason})')
+
+    def record(self, name, reason):
+        """Record a single item that could not be decoded."""
+        if self._note(self.records, name, reason):
+            log.debug(f' - Unparsed record in {self.artifact_label}: {name} ({reason})')
+
+    def result(self, count):
+        """Package `count` with what was lost, for the parser to return."""
+        return ParseResult(count, len(self.sources), len(self.records))
+
+
+
+
+@dataclasses.dataclass
+class ArtifactResult:
+    """What one artifact produced within one profile.
+
+    `count` and `status` are mutually exclusive in practice: an artifact either
+    yielded a number of records or it didn't yield one (and `status` says why).
+    `label` is how the artifact is named on screen and in output.
+
+    These three facets used to live in three parallel dicts (`artifacts_counts`,
+    `artifacts_display`, `artifacts_status`) with nothing keeping their keys in step,
+    so an artifact could pick up a label under one key and a count under another and
+    be reported twice -- once correctly, once as a phantom "0". One record per
+    artifact per profile makes that impossible.
+    """
+
+    key: str
+    label: str = None
+    count: int = None
+    status: str = None
+    # Set when the artifact parsed but some of it could not be read. See ParseResult
+    # for why the two levels are counted separately.
+    unparsed_sources: int = 0
+    unparsed_records: int = 0
+    # Why this artifact could not be read, when it couldn't -- kept on the record so a
+    # summary can state the reason rather than pointing at another log line.
+    detail: str = None
+
+    @property
+    def is_empty(self):
+        return self.label is None and self.count is None and self.status is None
+
+    @property
+    def is_partial(self):
+        return bool(self.unparsed_sources or self.unparsed_records)
+
+    def describe_unparsed(self):
+        """'3 sources, 5 records unparsed', or '' when nothing was lost."""
+        parts = []
+        if self.unparsed_sources:
+            parts.append(f'{self.unparsed_sources} '
+                         f'source{"s" if self.unparsed_sources != 1 else ""}')
+        if self.unparsed_records:
+            parts.append(f'{self.unparsed_records} '
+                         f'record{"s" if self.unparsed_records != 1 else ""}')
+        return f'{", ".join(parts)} unparsed' if parts else ''
+
 
 # Sorts before any real timestamp; only ever used to order un-timestamped items among
 # themselves, never rendered.
@@ -60,7 +199,10 @@ class ProcessingDisplay:
         with self.processing_display(["Group A", "Group B"]) as driver:
             driver.group("Group A")
             driver.run('URL', 'History', self.get_history, path, 'History', ...,
-                       display_key='History', display_value='URL records')
+                       display_value='URL records', artifact='history')
+
+    The parser returns its record count (or None if it could not read the artifact);
+    the driver records it under `count_key`. See `run()`.
     """
 
     count_width = 7
@@ -87,65 +229,191 @@ class ProcessingDisplay:
         """Set the group subsequent run() calls are bucketed under."""
         self.current_group = name
 
-    def run(self, label, count_key, func, *args, display_key=None, display_value=None,
+    def run(self, label, count_key, func, *args, display_value=None,
             artifact=None, **kwargs):
-        """Show a spinner row, run the parser, then replace it with its count.
+        """Show a spinner row, run the parser, then record what it produced.
+
+        This is the single place an artifact result is written. The driver already
+        knows the artifact's key, its label, and whether the run's filter wants it, so a
+        parser only has to say what it found. It returns one of:
+
+        * an ``int`` -- that many records, everything readable;
+        * a ``ParseResult`` -- a count plus what could not be read (see ParseFailures);
+        * ``None`` -- the artifact could not be read at all.
+
+        Parsers used to write into a shared `artifacts_counts` dict under a key they
+        derived themselves, which meant two layers were independently naming the same
+        artifact -- the source of every count/label/status key mismatch this removes.
 
         ``artifact`` is the catalog name from ``pyhindsight.artifact_filter`` that
-        ``--only`` / ``--skip`` select on. When the run's filter excludes it, the
-        parser is not called and the row reads "skipped" instead of a count, so a
-        filtered-out artifact never reads as an artifact that wasn't there.
+        ``--only`` / ``--skip`` select on. An excluded artifact is recorded as skipped
+        and its parser is never called, so a filtered-out artifact never reads as an
+        artifact that wasn't there.
         """
         group_rows = self.output_groups.setdefault(self.current_group, [])
-        display_label = display_value or self.browser.artifacts_display.get(display_key, label)
+        display_label = display_value or label
 
         artifact_filter = self.browser.artifact_filter
         if artifact_filter and not artifact_filter.should_parse(artifact):
             artifact_filter.note_skipped(artifact)
-            self.browser.artifacts_status[count_key] = ARTIFACT_STATUS_SKIPPED
+            self.browser.record_artifact(
+                count_key, label=display_label, status=ARTIFACT_STATUS_SKIPPED)
             log.info(f' - Skipping {label} ({artifact}); excluded by artifact filter')
-            # Neither artifacts_counts nor artifacts_display is written for a skipped
-            # artifact. Absent from artifacts_counts means "not parsed", which has to
-            # stay distinguishable from a count of zero -- and consumers that iterate
-            # artifacts_display key off it while defaulting the count to 0
-            # (parsed_artifacts.tpl does exactly that), so recording the label alone
-            # would render the artifact as "0" rather than omitting it.
-            group_rows.append((display_label, self._bracketed_count('skipped')))
+            group_rows.append((display_label, 'skipped', None))
             self._live.update(self._build_live_view())
             return
 
-        group_rows.append((display_label, self._bracketed_spinner()))
-        self._live.update(self._build_live_view())
-        func(*args, **kwargs)
-        if display_key and display_value:
-            self.browser.artifacts_display[display_key] = display_value
-        group_rows[-1] = (
-            display_label, self._bracketed_count(self.browser.artifacts_counts.get(count_key, "0")))
+        group_rows.append((display_label, _SPINNER, None))
         self._live.update(self._build_live_view())
 
-    def _build_table(self, rows, header_label):
+        sizes_before = self.browser.collection_sizes()
+        self.browser.last_open_failure = None
+        returned = func(*args, **kwargs)
+        sizes_after = self.browser.collection_sizes()
+        open_failure = self.browser.last_open_failure
+
+        if returned is None:
+            # The parser could not read its artifact. Recorded as a status, never as a
+            # count of 0, so "could not read this" stays distinguishable from "read it
+            # and found nothing".
+            detail = f'{open_failure[0]}: {open_failure[1]}' if open_failure else None
+            result = self.browser.record_artifact(
+                count_key, label=display_label, status=ARTIFACT_STATUS_FAILED,
+                detail=detail)
+            cell = 'Failed'
+            log.warning(f' - {display_label}: could not be read'
+                        + (f' -- {detail}' if detail else ''))
+        elif isinstance(returned, ParseResult):
+            result = self.browser.record_artifact(
+                count_key, label=display_label, count=returned.count,
+                unparsed_sources=returned.unparsed_sources,
+                unparsed_records=returned.unparsed_records,
+                status=ARTIFACT_STATUS_PARTIAL if returned.is_partial else None)
+            cell = returned.count
+        else:
+            result = self.browser.record_artifact(
+                count_key, label=display_label, count=returned)
+            cell = returned
+
+        self._reconcile_delivery(result, sizes_before, sizes_after)
+
+        # The summary line is built from the recorded result, so the totals in the log
+        # are by construction the totals rendered on screen.
+        if result.is_partial:
+            log.warning(f' - {display_label}: parsed {result.count}; '
+                        f'{result.describe_unparsed()}')
+        elif result.count is not None:
+            log.info(f' - {display_label}: parsed {result.count}')
+
+        group_rows[-1] = (display_label, cell, self._unparsed_note(result))
+        self._live.update(self._build_live_view())
+
+    @staticmethod
+    def _reconcile_delivery(result, sizes_before, sizes_after):
+        """Warn when a parser reported records but contributed none.
+
+        The count and the records travel separately: the count is returned, the records
+        are appended to one of the browser's collections. If a parser reports a positive
+        count and nothing grew, the records were built and then dropped -- the report
+        shows a confident number for data that is not in the output. That has happened,
+        and a count on its own cannot reveal it, because the count is correct.
+
+        Deliberately a weak invariant ("contributed *something*") rather than
+        "contributed exactly `count`": several parsers legitimately report a number that
+        is not the number of rows they emit -- Firefox's sessionstore counts entries seen
+        but emits de-duplicated rows, and Chrome's get_extensions counts extensions on
+        disk while its data goes to a different structure entirely.
+        """
+        if not result.count:
+            return
+        grew = any(sizes_after.get(name, 0) > sizes_before.get(name, 0)
+                   for name in set(sizes_after) | set(sizes_before))
+        if not grew:
+            log.error(
+                f' - {result.label or result.key}: reported {result.count} records but '
+                f'contributed none to the output; results were parsed and then dropped')
+
+    @staticmethod
+    def _unparsed_note(result):
+        """The "Unparsed" cell for a row, or None when the artifact was read in full.
+
+        Written without a leading minus: "1429 records" is a second fact about the
+        artifact, not a subtraction from the parsed count. Sources come first and are
+        coloured more urgently than records -- a source that would not open could have
+        held anything, so it is the finding that stops the parsed number being usable
+        as a total.
+        """
+        if not result.is_partial:
+            return None
+        text = rich.text.Text()
+        if result.unparsed_sources:
+            plural = 's' if result.unparsed_sources != 1 else ''
+            text.append(f'{result.unparsed_sources} source{plural}', style='red')
+        if result.unparsed_sources and result.unparsed_records:
+            text.append(', ', style='dim')
+        if result.unparsed_records:
+            plural = 's' if result.unparsed_records != 1 else ''
+            text.append(f'{result.unparsed_records} record{plural}', style='yellow')
+        return text
+
+    note_width = 22
+
+    def _render_cell(self, value):
+        """The bracketed count for one row."""
+        if value is _SPINNER:
+            return self._bracketed_spinner()
+        return self._bracketed_count(value)
+
+    def _any_unparsed(self):
+        """True if anything anywhere in this profile went unparsed.
+
+        Decided once for the whole run rather than per group: a column present on some
+        groups and absent on others gives the tables different widths, and the sections
+        stop lining up under each other.
+        """
+        return any(row[2] is not None
+                   for rows in self.output_groups.values() for row in rows)
+
+    def _build_table(self, rows, header_label, show_unparsed):
+        label_width = self.table_width - self.count_width - 8
+        count_width = self.count_width + 8
+
         # Header row as separate table with center alignment
         header = rich.table.Table(show_header=False, box=None, expand=False)
-        header.add_column(justify="left", width=self.table_width - self.count_width - 8, style="bold on #333333")
-        header.add_column(justify="center", width=self.count_width + 8, style="bold on #333333")
-        header.add_row(rich.text.Text(header_label, style="bold"), rich.text.Text("Count", style="bold"))
+        header.add_column(justify="left", width=label_width, style="bold on #333333")
+        header.add_column(justify="center", width=count_width, style="bold on #333333")
+        cells = [rich.text.Text(header_label, style="bold"),
+                 rich.text.Text("Parsed", style="bold")]
+        if show_unparsed:
+            header.add_column(justify="left", width=self.note_width,
+                              style="bold on #333333")
+            cells.append(rich.text.Text("Unparsed", style="bold"))
+        header.add_row(*cells)
 
         # Content table with right alignment
         table = rich.table.Table(show_header=False, box=None, expand=False)
-        table.add_column(overflow="fold", justify="right", width=self.table_width - self.count_width - 8)
-        table.add_column(justify="center", width=self.count_width + 8, no_wrap=True)
-        for row_label, row_count in rows:
-            table.add_row(row_label, row_count)
+        table.add_column(overflow="fold", justify="right", width=label_width)
+        table.add_column(justify="center", width=count_width, no_wrap=True)
+        if show_unparsed:
+            table.add_column(justify="left", width=self.note_width, no_wrap=True)
+        for row_label, value, note in rows:
+            cell = self._render_cell(value)
+            if show_unparsed:
+                table.add_row(row_label, cell,
+                              note if note is not None else rich.text.Text(''))
+            else:
+                table.add_row(row_label, cell)
         return rich.console.Group(header, table)
 
     def _build_group_tables(self):
+        show_unparsed = self._any_unparsed()
         tables = []
         for group_name in self.group_order:
             rows = self.output_groups.get(group_name, [])
             if not rows:
                 continue
-            inner_table = self._build_table(rows, group_name)
-            tables.append(rich.align.Align.center(inner_table))
+            tables.append(rich.align.Align.center(
+                self._build_table(rows, group_name, show_unparsed)))
             tables.append(rich.text.Text(""))  # Padding between groups
         return rich.console.Group(*tables)
 
@@ -171,10 +439,12 @@ class ProcessingDisplay:
             padding=(0, 0))
         return spinner
 
-    def _bracketed_count(self, count):
+    def _bracketed_count(self, count, style=None):
         text = rich.text.Text()
         text.append("[ ", style="dim")
-        if str(count) == "Failed":
+        if style is not None:
+            text.append(f"{count:>{self.count_width}}", style=style)
+        elif str(count) == "Failed":
             text.append(f"{count:>{self.count_width}}", style="red")
         elif str(count) == "skipped":
             text.append(f"{count:>{self.count_width}}", style="yellow")
@@ -204,11 +474,13 @@ class WebBrowser(object):
         self.parsed_storage = []
         self.parsed_extension_data = []
         self.parsed_sync_data = []
-        self.artifacts_counts = {}
-        self.artifacts_display = {}
-        # {count_key: status}, for artifacts that produced an outcome rather than a
-        # count. See finalize_artifact_status().
-        self.artifacts_status = {}
+        # One record per artifact, keyed by the artifact's count key. The three
+        # `artifacts_*` mappings below are views onto these records, not separate
+        # stores, so a label and a count can never end up under different keys.
+        self.artifact_results = {}
+        # (path, reason) of the most recent database that could not be opened; the
+        # driver consumes it so a failed artifact can name the file and the reason.
+        self.last_open_failure = None
         self.preferences = []
         self.no_copy = no_copy
         self.temp_dir = temp_dir
@@ -218,29 +490,84 @@ class WebBrowser(object):
         if self.version is None:
             self.version = []
 
-    def finalize_artifact_status(self):
-        """Move sentinel status strings out of `artifacts_counts` into `artifacts_status`.
+    def describe_open_failure(self, default='could not be opened'):
+        """Why the last database open failed, for a parser to attach to an unparsed source.
 
-        Parsers signal a failed parse by writing the string ``'Failed'`` into
-        `artifacts_counts` -- the same dict that holds record counts. Mixing the two
-        forces every consumer to special-case strings, and the aggregation in
-        AnalysisSession used to resolve them by substituting ``0``, silently turning
-        "couldn't read this artifact" into "read it and found nothing". Those are
-        opposite findings, so the status is moved somewhere it can't be mistaken for a
-        count, and the key is removed from `artifacts_counts` entirely: absent means
-        "no count was produced", which stays distinguishable from a count of zero.
-
-        Called at the end of each browser's process(), after the live display has
-        finished reading counts, so the on-screen "[ Failed ]" rendering is unaffected.
-        Idempotent.
+        Without this a parser can only say "could not be opened" while the actual reason
+        ("file is not a database", "database disk image is malformed") sits in a separate
+        line written by a different module.
         """
-        for count_key, value in list(self.artifacts_counts.items()):
-            if isinstance(value, str):
-                # Recorded verbatim (lowercased) rather than validated against a known
-                # set. A status nobody anticipated is still information, and dropping
-                # or rejecting it is how the old code lost failures.
-                self.artifacts_status[count_key] = value.lower()
-                del self.artifacts_counts[count_key]
+        if self.last_open_failure:
+            return self.last_open_failure[1]
+        return default
+
+    def collection_sizes(self):
+        """{collection name: current size} for everything a parser can deliver into.
+
+        Used by the driver to reconcile what a parser *reported* against what it
+        actually contributed. A count is derived from a list the parser built; the
+        records reach output through a separate `extend`. Those two can disagree --
+        a misplaced return, an early exit, a lost extend -- and the count alone gives
+        no hint, because it is right.
+        """
+        sizes = {}
+        for name in RESULT_COLLECTIONS:
+            value = getattr(self, name, None)
+            if value is None:
+                continue
+            if isinstance(value, dict):
+                # e.g. installed_extensions is {'data': [...], 'presentation': ...}
+                data = value.get('data')
+                sizes[name] = len(data) if isinstance(data, list) else len(value)
+                continue
+            try:
+                sizes[name] = len(value)
+            except TypeError:
+                continue
+        return sizes
+
+    def record_artifact(self, key, label=None, count=None, status=None,
+                        unparsed_sources=None, unparsed_records=None, detail=None):
+        """Record what one artifact produced in this profile.
+
+        Called by ``ProcessingDisplay.run()``, which is the only writer. Fields left
+        as None are not overwritten, so a later call can add to an existing record.
+        """
+        result = self.artifact_results.get(key)
+        if result is None:
+            result = self.artifact_results[key] = ArtifactResult(key)
+        if label is not None:
+            result.label = label
+        if count is not None:
+            result.count = count
+        if status is not None:
+            result.status = status
+        if unparsed_sources is not None:
+            result.unparsed_sources = unparsed_sources
+        if unparsed_records is not None:
+            result.unparsed_records = unparsed_records
+        if detail is not None:
+            result.detail = detail
+        return result
+
+    # The three mappings below are derived from `artifact_results`, which is the single
+    # source of truth. They are read-only on purpose: they used to be three independent
+    # dicts that parsers wrote into directly, and nothing kept their keys in step.
+
+    @property
+    def artifacts_counts(self):
+        """{artifact key: record count} for artifacts that produced a count."""
+        return {k: r.count for k, r in self.artifact_results.items() if r.count is not None}
+
+    @property
+    def artifacts_display(self):
+        """{artifact key: human-readable label}."""
+        return {k: r.label for k, r in self.artifact_results.items() if r.label is not None}
+
+    @property
+    def artifacts_status(self):
+        """{artifact key: 'failed'|'skipped'} for artifacts that produced no count."""
+        return {k: r.status for k, r in self.artifact_results.items() if r.status is not None}
 
     @staticmethod
     def format_processing_output(name, items):
@@ -276,7 +603,9 @@ class WebBrowser(object):
             # Copy and connect to copy of SQLite DB
             conn = utils.open_sqlite_db(self, path, database)
             if not conn:
-                self.artifacts_counts[database] = 'Failed'
+                # No artifact result is recorded here: this is schema probing, not a
+                # parse. Whichever parser needs this database will report its own
+                # failure, under its own key.
                 return
             try:
                 cursor = conn.cursor()

--- a/pyhindsight/templates/parsed_artifacts.tpl
+++ b/pyhindsight/templates/parsed_artifacts.tpl
@@ -10,14 +10,19 @@
             </tr>
          % display_items = list(artifacts_display.keys())
          % status_summary = artifact_status_summary if defined('artifact_status_summary') else {}
+         % described = artifact_status_descriptions if defined('artifact_status_descriptions') else {}
          % def cell(key):
+         %     # A count of 0 means "parsed, found nothing". Anything else -- failed,
+         %     # skipped, or parsed-but-incomplete -- says so instead of showing a bare
+         %     # number that reads as a complete result.
          %     statuses = status_summary.get(key)
          %     count = artifacts_counts.get(key)
+         %     detail = described.get(key) or ('/'.join(sorted(statuses)) if statuses else '')
          %     if statuses and count is None:
-         %         return '/'.join(sorted(statuses))
+         %         return detail
          %     end
          %     if statuses:
-         %         return '{} ({})'.format(count, '/'.join(sorted(statuses)))
+         %         return '{} ({})'.format(count, detail)
          %     end
          %     return 0 if count is None else count
          % end

--- a/pyhindsight/utils.py
+++ b/pyhindsight/utils.py
@@ -40,11 +40,27 @@ def text_factory(row_data):
         return row_data
 
 
+def note_open_failure(browser, database_path, database_name, reason):
+    """Remember why a database could not be opened, for the caller to report.
+
+    The parser that asked for the database usually turns a failure into `return None`,
+    which reaches the driver as "this artifact could not be read" -- true, but with the
+    reason left behind in an unrelated log line. Stashing it here lets the artifact's own
+    summary line name the file and the reason, so the log can be read top-down.
+    """
+    try:
+        browser.last_open_failure = (
+            os.path.join(database_path, database_name), str(reason))
+    except AttributeError:
+        pass
+
+
 def open_sqlite_db(chrome, database_path, database_name):
     log.info(f' - Reading from {database_name} in {database_path}')
 
     if not os.path.exists(os.path.join(database_path, database_name)):
         log.info(f'   - Failed; {database_name} does not exist in {database_path}')
+        note_open_failure(chrome, database_path, database_name, 'file does not exist')
         return False
 
     if chrome.no_copy:
@@ -63,6 +79,7 @@ def open_sqlite_db(chrome, database_path, database_name):
                     shutil.copyfile(src, db_path_to_open + suffix)
         except Exception as e:
             log.error(f' - Error copying {database_name}: {e}')
+            note_open_failure(chrome, database_path, database_name, f'could not be copied ({e})')
             return None
 
     db_conn = None
@@ -79,6 +96,7 @@ def open_sqlite_db(chrome, database_path, database_name):
 
     except Exception as e:
         log.error(f' - Error opening {database_name}: {e}')
+        note_open_failure(chrome, database_path, database_name, str(e))
         if db_conn is not None:
             db_conn.close()
         return None

--- a/tests/test_artifact_filter.py
+++ b/tests/test_artifact_filter.py
@@ -197,31 +197,24 @@ class TestParserCallSitesAreTagged(unittest.TestCase):
     def test_every_driver_run_call_is_tagged(self):
         # An untagged call site parses unconditionally, so --only/--skip would quietly
         # have no effect on it. Catch that here rather than in an investigation.
+        # Parsed rather than grepped: the source also *mentions* driver.run() in prose.
+        import ast
         import inspect
-        import re
         from pyhindsight.browsers import chrome, firefox
         for module in (chrome, firefox):
-            path = inspect.getfile(module)
-            with open(path, encoding='utf-8') as source:
-                text = source.read()
-            call_count = len(re.findall(r'driver\.run\(', text))
-            tagged_count = len(re.findall(r'\n\s*artifact=', text))
-            self.assertEqual(
-                call_count, tagged_count,
-                f'{path}: {call_count} driver.run() calls but {tagged_count} artifact= tags')
-
-
-class _FakeBrowser:
-    """Minimal stand-in for the browser state ProcessingDisplay reads."""
-
-    def __init__(self, artifact_filter_):
-        self.artifact_filter = artifact_filter_
-        self.artifacts_counts = {}
-        self.artifacts_display = {}
-        self.artifacts_status = {}
-        self.profile_path = 'fixture-profile'
-        self.browser_name = 'Chrome'
-        self.display_version = '999'
+            source = inspect.getsource(module)
+            untagged = []
+            for node in ast.walk(ast.parse(source)):
+                if not (isinstance(node, ast.Call)
+                        and isinstance(node.func, ast.Attribute)
+                        and node.func.attr == 'run'
+                        and isinstance(node.func.value, ast.Name)
+                        and node.func.value.id == 'driver'):
+                    continue
+                if not any(kw.arg == 'artifact' for kw in node.keywords):
+                    untagged.append(f'{module.__name__} line {node.lineno}')
+            self.assertEqual([], untagged,
+                             f'untagged driver.run() calls: {untagged}')
 
 
 class TestProcessingDisplayHonorsFilter(unittest.TestCase):
@@ -230,20 +223,32 @@ class TestProcessingDisplayHonorsFilter(unittest.TestCase):
     def _driver(self, artifact_filter_):
         import io
         import rich.console
-        from pyhindsight.browsers.webbrowser import ProcessingDisplay
+        from pyhindsight.browsers.webbrowser import ProcessingDisplay, WebBrowser
 
-        driver = ProcessingDisplay(_FakeBrowser(artifact_filter_), ['Group'])
+        browser = WebBrowser('fixture-profile', 'Chrome', artifact_filter=artifact_filter_)
+        browser.display_version = '999'
+        driver = ProcessingDisplay(browser, ['Group'])
         # Render into a buffer so the test doesn't paint the terminal.
         driver.console = rich.console.Console(file=io.StringIO(), width=100)
         return driver
+
+    @staticmethod
+    def _parser(browser, count=None, calls=None, name=None):
+        """A stand-in parser: returns a count, or None to mean "could not read"."""
+        def run():
+            if calls is not None:
+                calls.append(name)
+            return count
+        return run
 
     def test_excluded_parser_is_not_called(self):
         calls = []
         driver = self._driver(ArtifactFilter.from_selectors(skip_tokens=['cache']))
         with driver:
             driver.group('Group')
-            driver.run('Cache', 'Cache', lambda: calls.append('cache'),
-                       display_key='Cache', display_value='Cache records', artifact='cache')
+            driver.run('Cache', 'Cache',
+                       self._parser(driver.browser, 5, calls, 'cache'),
+                       display_value='Cache records', artifact='cache')
         self.assertEqual([], calls)
 
     def test_included_parser_is_called(self):
@@ -251,48 +256,60 @@ class TestProcessingDisplayHonorsFilter(unittest.TestCase):
         driver = self._driver(ArtifactFilter.from_selectors(skip_tokens=['cache']))
         with driver:
             driver.group('Group')
-            driver.run('URL', 'History', lambda: calls.append('history'),
-                       display_key='History', display_value='URL records', artifact='history')
+            driver.run('URL', 'History',
+                       self._parser(driver.browser, 3, calls, 'history'),
+                       display_value='URL records', artifact='history')
         self.assertEqual(['history'], calls)
+        self.assertEqual({'History': 3}, driver.browser.artifacts_counts)
 
-    def test_excluded_artifact_writes_no_count(self):
-        # Absent from artifacts_counts means "not parsed", which has to stay
-        # distinguishable from a parsed artifact that found nothing (a count of 0).
+    def test_excluded_artifact_is_recorded_as_skipped_not_as_zero(self):
+        # A count of 0 would read as "parsed fine, found nothing"; the artifact was
+        # never parsed at all.
         driver = self._driver(ArtifactFilter.from_selectors(skip_tokens=['cache']))
         with driver:
             driver.group('Group')
-            driver.run('Cache', 'Cache', lambda: None,
-                       display_key='Cache', display_value='Cache records', artifact='cache')
+            driver.run('Cache', 'Cache', self._parser(driver.browser, 5),
+                       display_value='Cache records', artifact='cache')
         self.assertNotIn('Cache', driver.browser.artifacts_counts)
+        self.assertEqual({'Cache': 'skipped'}, driver.browser.artifacts_status)
 
-    def test_excluded_artifact_writes_no_display_label(self):
-        # Consumers iterate artifacts_display and default a missing count to 0
-        # (parsed_artifacts.tpl), so recording the label without a count would render
-        # a skipped artifact as "0" instead of leaving it out.
+    def test_excluded_artifact_keeps_its_label(self):
+        # One record per artifact: the label rides along with the status, so output can
+        # name what it skipped instead of dropping the row.
         driver = self._driver(ArtifactFilter.from_selectors(skip_tokens=['cache']))
         with driver:
             driver.group('Group')
-            driver.run('Cache', 'Cache', lambda: None,
-                       display_key='Cache', display_value='Cache records', artifact='cache')
-        self.assertNotIn('Cache', driver.browser.artifacts_display)
-
-    def test_excluded_artifact_still_shows_its_label_on_screen(self):
-        # Dropping the artifacts_display write must not blank the row in the live UI.
-        driver = self._driver(ArtifactFilter.from_selectors(skip_tokens=['cache']))
-        with driver:
-            driver.group('Group')
-            driver.run('Cache', 'Cache', lambda: None,
-                       display_key='Cache', display_value='Cache records', artifact='cache')
-        label, _ = driver.output_groups['Group'][0]
+            driver.run('Cache', 'Cache', self._parser(driver.browser, 5),
+                       display_value='Cache records', artifact='cache')
+        self.assertEqual({'Cache': 'Cache records'}, driver.browser.artifacts_display)
+        label = driver.output_groups['Group'][0][0]
         self.assertEqual('Cache records', label)
+
+    def test_a_failing_parser_is_recorded_as_failed(self):
+        driver = self._driver(ArtifactFilter())
+        with driver:
+            driver.group('Group')
+            driver.run('Cookies', 'Cookies', self._parser(driver.browser, None),
+                       display_value='Cookie records', artifact='cookies')
+        self.assertNotIn('Cookies', driver.browser.artifacts_counts)
+        self.assertEqual({'Cookies': 'failed'}, driver.browser.artifacts_status)
+
+    def test_a_zero_count_is_not_a_failure(self):
+        driver = self._driver(ArtifactFilter())
+        with driver:
+            driver.group('Group')
+            driver.run('IndexedDB', 'IndexedDB', self._parser(driver.browser, 0),
+                       display_value='IndexedDB records', artifact='indexeddb')
+        self.assertEqual({'IndexedDB': 0}, driver.browser.artifacts_counts)
+        self.assertEqual({}, driver.browser.artifacts_status)
 
     def test_excluded_artifact_is_recorded_on_the_filter(self):
         artifact_filter_ = ArtifactFilter.from_selectors(skip_tokens=['cache'])
         driver = self._driver(artifact_filter_)
         with driver:
             driver.group('Group')
-            driver.run('Cache', 'Cache', lambda: None,
-                       display_key='Cache', display_value='Cache records', artifact='cache')
+            driver.run('Cache', 'Cache', self._parser(driver.browser, 5),
+                       display_value='Cache records', artifact='cache')
         self.assertEqual({'cache'}, artifact_filter_.skipped_artifacts)
 
     def test_untagged_call_runs_under_an_only_filter(self):
@@ -300,8 +317,22 @@ class TestProcessingDisplayHonorsFilter(unittest.TestCase):
         driver = self._driver(ArtifactFilter.from_selectors(only_tokens=['history']))
         with driver:
             driver.group('Group')
-            driver.run('Mystery', 'Mystery', lambda: calls.append('mystery'))
+            driver.run('Mystery', 'Mystery',
+                       self._parser(driver.browser, 1, calls, 'mystery'))
         self.assertEqual(['mystery'], calls)
+
+    def test_a_parser_that_returns_nothing_is_recorded_as_failed(self):
+        # Returning None is the failure signal, so a parser that falls off the end is
+        # reported as a failure rather than silently inheriting anything.
+        driver = self._driver(ArtifactFilter())
+        with driver:
+            driver.group('Group')
+            driver.run('History', 'History', self._parser(driver.browser, 7),
+                       display_value='URL records', artifact='history')
+            driver.run('Quiet', 'Quiet', lambda: None, display_value='Quiet records')
+        self.assertEqual({'History': 7}, driver.browser.artifacts_counts)
+        self.assertNotIn('Quiet', driver.browser.artifacts_counts)
+        self.assertEqual('failed', driver.browser.artifacts_status['Quiet'])
 
 
 if __name__ == '__main__':

--- a/tests/test_artifact_status.py
+++ b/tests/test_artifact_status.py
@@ -4,213 +4,251 @@ from pyhindsight.analysis import AnalysisSession
 from pyhindsight.browsers.webbrowser import (
     ARTIFACT_STATUS_FAILED,
     ARTIFACT_STATUS_SKIPPED,
+    ArtifactResult,
     WebBrowser,
 )
 
 
-def _browser(counts=None, status=None):
-    browser = WebBrowser('profile', 'Chrome')
-    browser.artifacts_counts = dict(counts or {})
-    browser.artifacts_status = dict(status or {})
-    return browser
+class TestParserReturnContract(unittest.TestCase):
+    """Parsers return a count; they never name the artifact they parsed.
 
-
-class TestFinalizeArtifactStatus(unittest.TestCase):
-    """Parsers write 'Failed' into the counts dict; finalization splits it back out."""
-
-    def test_failure_moves_out_of_counts_into_status(self):
-        browser = _browser({'History': 500, 'Cookies': 'Failed'})
-        browser.finalize_artifact_status()
-        self.assertEqual({'History': 500}, browser.artifacts_counts)
-        self.assertEqual({'Cookies': ARTIFACT_STATUS_FAILED}, browser.artifacts_status)
-
-    def test_failure_does_not_become_a_count_of_zero(self):
-        # The bug this replaces: a failed parse used to be reported as "found nothing".
-        browser = _browser({'Cookies': 'Failed'})
-        browser.finalize_artifact_status()
-        self.assertNotIn('Cookies', browser.artifacts_counts)
-
-    def test_genuine_zero_count_is_left_alone(self):
-        # The other half of the distinction: 0 is a real, parsed result.
-        browser = _browser({'IndexedDB': 0})
-        browser.finalize_artifact_status()
-        self.assertEqual({'IndexedDB': 0}, browser.artifacts_counts)
-        self.assertEqual({}, browser.artifacts_status)
-
-    def test_unrecognized_status_is_preserved_not_rejected(self):
-        # The old merge raised ValueError on any status that wasn't 'Fail...'. A status
-        # nobody anticipated is still information; losing it is how failures went missing.
-        browser = _browser({'Cache': 'Aborted'})
-        browser.finalize_artifact_status()
-        self.assertEqual({'Cache': 'aborted'}, browser.artifacts_status)
-        self.assertNotIn('Cache', browser.artifacts_counts)
-
-    def test_is_idempotent(self):
-        browser = _browser({'History': 5, 'Cookies': 'Failed'})
-        browser.finalize_artifact_status()
-        browser.finalize_artifact_status()
-        self.assertEqual({'History': 5}, browser.artifacts_counts)
-        self.assertEqual({'Cookies': ARTIFACT_STATUS_FAILED}, browser.artifacts_status)
-
-    def test_existing_status_entries_survive(self):
-        # A skip recorded during the run must not be clobbered by finalization.
-        browser = _browser({'History': 5}, {'Cache': ARTIFACT_STATUS_SKIPPED})
-        browser.finalize_artifact_status()
-        self.assertEqual({'Cache': ARTIFACT_STATUS_SKIPPED}, browser.artifacts_status)
-
-
-class TestSumDictCounts(unittest.TestCase):
-
-    def test_sums_shared_keys(self):
-        self.assertEqual(
-            {'History': 30, 'Cookies': 5},
-            AnalysisSession.sum_dict_counts({'History': 10, 'Cookies': 5}, {'History': 20}))
-
-    def test_keys_only_in_one_dict_are_kept(self):
-        self.assertEqual(
-            {'History': 10, 'Cookies': 5},
-            AnalysisSession.sum_dict_counts({'History': 10}, {'Cookies': 5}))
-
-    def test_a_status_string_is_a_loud_error_not_a_silent_zero(self):
-        # Previously this returned {'Cookies': 0}, reporting a failed parse as an empty
-        # one. Reaching here now means finalize_artifact_status() was bypassed.
-        with self.assertRaises(TypeError) as raised:
-            AnalysisSession.sum_dict_counts({}, {'Cookies': 'Failed'})
-        self.assertIn('finalize_artifact_status', str(raised.exception))
-
-
-class TestSessionStatusAggregation(unittest.TestCase):
-    """Failures have to stay attached to the profile they happened in."""
-
-    def _session(self, *profiles):
-        session = AnalysisSession()
-        session.profile_paths = [name for name, _, _ in profiles]
-        for name, counts, status in profiles:
-            browser = _browser(counts, status)
-            session.artifacts_counts = session.sum_dict_counts(
-                session.artifacts_counts, browser.artifacts_counts)
-            session.record_artifact_status(name, browser)
-        return session
-
-    def test_status_is_recorded_per_profile(self):
-        session = self._session(
-            ('/p1', {'Cookies': 50}, {}),
-            ('/p2', {}, {'Cookies': ARTIFACT_STATUS_FAILED}))
-        self.assertEqual({'/p2': {'Cookies': ARTIFACT_STATUS_FAILED}}, session.artifacts_status)
-
-    def test_a_failure_in_one_profile_is_not_hidden_by_another_profiles_count(self):
-        # The old merge returned {'Cookies': 50} with no trace that a profile failed.
-        session = self._session(
-            ('/p1', {'Cookies': 50}, {}),
-            ('/p2', {}, {'Cookies': ARTIFACT_STATUS_FAILED}))
-        self.assertEqual(50, session.artifacts_counts['Cookies'])
-        self.assertEqual('failed in 1 of 2 profiles', session.describe_artifact_status('Cookies'))
-
-    def test_summary_lists_the_affected_profiles(self):
-        session = self._session(
-            ('/p1', {}, {'Cache': ARTIFACT_STATUS_FAILED}),
-            ('/p2', {}, {'Cache': ARTIFACT_STATUS_FAILED}))
-        self.assertEqual(
-            {'Cache': {ARTIFACT_STATUS_FAILED: ['/p1', '/p2']}},
-            session.artifact_status_summary())
-
-    def test_single_profile_status_is_described_without_a_profile_count(self):
-        session = self._session(('/p1', {}, {'Cache': ARTIFACT_STATUS_SKIPPED}))
-        self.assertEqual('skipped', session.describe_artifact_status('Cache'))
-
-    def test_artifact_with_no_status_describes_as_none(self):
-        session = self._session(('/p1', {'History': 10}, {}))
-        self.assertIsNone(session.describe_artifact_status('History'))
-
-
-class TestFailureKeysMatchCountKeys(unittest.TestCase):
-    """A parser must report a failure under the same key it reports a count under.
-
-    The live display and the run's status summary look an artifact up by its count key.
-    A failure filed under a different key (Firefox used to file several under the
-    *filename*) is invisible to both: the display falls back to "0", which reads as
-    "parsed fine, found nothing" rather than "could not read". Nothing but convention
-    keeps the two keys in step, so this checks the source directly.
+    The key belongs to the driver.run() call that invoked the parser. Parsers used to
+    write into a shared dict under a key derived from their own arguments, so two
+    layers named the same artifact independently and could disagree.
     """
 
-    BROWSER_MODULES = ('chrome', 'firefox')
-
-    # Helpers that open a database on a parser's behalf and record the failure for it.
-    # They take the key as a keyword so the caller stays responsible for naming it.
-    OPEN_HELPERS = {'_open'}
+    PARSER_MODULES = ('chrome', 'firefox')
 
     @staticmethod
-    def _count_key_source(subscript, source):
-        import ast
-        return ast.get_source_segment(source, subscript.slice)
+    def _own_nodes(fn):
+        """Walk a function's own body, not the bodies of functions nested inside it.
 
-    def _mismatches(self, module_name):
+        Several parsers define local helpers whose `return` statements say nothing
+        about what the parser itself hands back.
+        """
+        import ast
+        nested = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)
+        stack = list(fn.body)
+        while stack:
+            node = stack.pop()
+            if isinstance(node, nested):
+                # A locally-defined helper: neither it nor anything inside it belongs
+                # to the parser's own control flow.
+                continue
+            yield node
+            stack.extend(ast.iter_child_nodes(node))
+
+    def _driver_targets(self, module_name):
+        """The parser functions reached through driver.run() in this module."""
         import ast
         import importlib
         import inspect
 
         module = importlib.import_module(f'pyhindsight.browsers.{module_name}')
         source = inspect.getsource(module)
-        tree = ast.parse(source)
+        names = set()
+        for node in ast.walk(ast.parse(source)):
+            if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == 'run'
+                    and isinstance(node.func.value, ast.Name)
+                    and node.func.value.id == 'driver'):
+                target = node.args[2]
+                if isinstance(target, ast.Attribute):
+                    names.add(target.attr)
+        return module, source, names
 
-        found = []
-        for class_node in [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]:
-            for fn in [n for n in class_node.body if isinstance(n, ast.FunctionDef)]:
-                count_keys, failure_keys = set(), set()
-                for node in ast.walk(fn):
-                    if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
-                            and node.func.attr in self.OPEN_HELPERS):
-                        for keyword in node.keywords:
-                            if keyword.arg == 'count_key':
-                                key = ast.get_source_segment(source, keyword.value)
-                                # None means "a probe, not an artifact parse".
-                                if key != 'None':
-                                    failure_keys.add(key)
-                    if isinstance(node, ast.Assign) and len(node.targets) == 1:
-                        target = node.targets[0]
-                        if (isinstance(target, ast.Subscript)
-                                and isinstance(target.value, ast.Attribute)
-                                and target.value.attr == 'artifacts_counts'):
-                            key = self._count_key_source(target, source)
-                            is_status = (isinstance(node.value, ast.Constant)
-                                         and isinstance(node.value.value, str))
-                            (failure_keys if is_status else count_keys).add(key)
-
-                # Only meaningful for parsers that report a count at all.
-                if not count_keys:
-                    continue
-                stray = failure_keys - count_keys
-                if stray:
-                    found.append(f'{module_name}.{fn.name}: '
-                                 f'counts under {sorted(count_keys)}, '
-                                 f'fails under {sorted(stray)}')
-        return found
-
-    def test_no_parser_files_a_failure_under_a_key_it_never_counts(self):
-        mismatches = []
-        for module_name in self.BROWSER_MODULES:
-            mismatches.extend(self._mismatches(module_name))
-        self.assertEqual([], mismatches, '\n' + '\n'.join(mismatches))
-
-    def test_the_check_would_catch_a_regression(self):
-        # Guard against the audit silently passing because it stopped finding anything.
+    def test_every_parser_returns_something(self):
+        # A parser that falls off the end returns None, which the driver records as a
+        # failed parse. That would be a silent, visible-only-at-runtime regression.
         import ast
-        source = (
-            'class P:\n'
-            '    def get_thing(self, database):\n'
-            "        self.artifacts_counts[database] = 'Failed'\n"
-            "        self.artifacts_counts['Thing'] = 5\n")
-        tree = ast.parse(source)
-        fn = tree.body[0].body[0]
-        count_keys, failure_keys = set(), set()
-        for node in ast.walk(fn):
-            if isinstance(node, ast.Assign):
+        for module_name in self.PARSER_MODULES:
+            module, source, targets = self._driver_targets(module_name)
+            self.assertTrue(targets, module_name)
+            tree = ast.parse(source)
+            for cls in [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]:
+                for fn in [n for n in cls.body if isinstance(n, ast.FunctionDef)]:
+                    if fn.name not in targets:
+                        continue
+                    returns_value = any(
+                        isinstance(n, ast.Return) and n.value is not None
+                        for n in self._own_nodes(fn))
+                    self.assertTrue(
+                        returns_value,
+                        f'{module_name}.{fn.name} never returns a count; the driver '
+                        f'would record it as a failed parse')
+
+    def test_no_parser_returns_a_bare_value_less_return(self):
+        # `return` with no value means None means "failed". Every early exit that is
+        # not a failure has to say what it produced.
+        import ast
+        for module_name in self.PARSER_MODULES:
+            module, source, targets = self._driver_targets(module_name)
+            offenders = []
+            tree = ast.parse(source)
+            for cls in [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]:
+                for fn in [n for n in cls.body if isinstance(n, ast.FunctionDef)]:
+                    if fn.name not in targets:
+                        continue
+                    for n in self._own_nodes(fn):
+                        if isinstance(n, ast.Return) and n.value is None:
+                            offenders.append(f'{module_name}.{fn.name} line {n.lineno}')
+            self.assertEqual(
+                [], offenders,
+                'bare `return` in a parser is ambiguous -- use `return None` for a '
+                f'failure or return a count: {offenders}')
+
+
+class TestArtifactRecords(unittest.TestCase):
+    """One record per artifact holds its label, count, and status together."""
+
+    def setUp(self):
+        self.browser = WebBrowser('profile', 'Chrome')
+
+    def test_record_populates_the_derived_views(self):
+        self.browser.record_artifact('History', label='URL records', count=500)
+        self.assertEqual({'History': 500}, self.browser.artifacts_counts)
+        self.assertEqual({'History': 'URL records'}, self.browser.artifacts_display)
+        self.assertEqual({}, self.browser.artifacts_status)
+
+    def test_a_failed_artifact_has_a_status_and_no_count(self):
+        self.browser.record_artifact('Cookies', label='Cookie records',
+                                     status=ARTIFACT_STATUS_FAILED)
+        self.assertNotIn('Cookies', self.browser.artifacts_counts)
+        self.assertEqual({'Cookies': ARTIFACT_STATUS_FAILED}, self.browser.artifacts_status)
+
+    def test_a_zero_count_is_kept_as_a_count(self):
+        self.browser.record_artifact('IndexedDB', label='IndexedDB records', count=0)
+        self.assertEqual({'IndexedDB': 0}, self.browser.artifacts_counts)
+        self.assertEqual({}, self.browser.artifacts_status)
+
+    def test_label_and_count_cannot_land_under_different_keys(self):
+        # The point of one record per artifact: a label always belongs to an artifact
+        # that also carries the count, so no phantom "0" row can appear.
+        self.browser.record_artifact('Cookies', label='Cookie records', count=3)
+        self.assertEqual(set(self.browser.artifacts_display),
+                         set(self.browser.artifacts_counts))
+
+    def test_later_calls_add_to_an_existing_record(self):
+        self.browser.record_artifact('Cache', label='Cache records')
+        self.browser.record_artifact('Cache', count=7)
+        result = self.browser.artifact_results['Cache']
+        self.assertEqual(ArtifactResult('Cache', label='Cache records', count=7), result)
+
+    def test_derived_views_are_read_only(self):
+        # They used to be independently writable dicts, which is how they drifted apart.
+        with self.assertRaises(AttributeError):
+            self.browser.artifacts_counts = {'History': 1}
+
+
+class TestSessionAggregation(unittest.TestCase):
+    """Counts sum across profiles; outcomes stay attached to their profile."""
+
+    def _session(self, *profiles):
+        session = AnalysisSession()
+        session.profile_paths = [name for name, _ in profiles]
+        for name, records in profiles:
+            browser = WebBrowser(name, 'Chrome')
+            for key, kwargs in records.items():
+                browser.record_artifact(key, **kwargs)
+            session.record_profile_results(name, browser)
+        return session
+
+    def test_counts_are_summed_across_profiles(self):
+        session = self._session(
+            ('/p1', {'History': dict(count=10, label='URL records')}),
+            ('/p2', {'History': dict(count=25, label='URL records')}))
+        self.assertEqual({'History': 35}, session.artifacts_counts)
+
+    def test_status_is_recorded_per_profile(self):
+        session = self._session(
+            ('/p1', {'Cookies': dict(count=50)}),
+            ('/p2', {'Cookies': dict(status=ARTIFACT_STATUS_FAILED)}))
+        self.assertEqual({'/p2': {'Cookies': ARTIFACT_STATUS_FAILED}},
+                         session.artifacts_status)
+
+    def test_a_failure_in_one_profile_is_not_hidden_by_another_profiles_count(self):
+        session = self._session(
+            ('/p1', {'Cookies': dict(count=50)}),
+            ('/p2', {'Cookies': dict(status=ARTIFACT_STATUS_FAILED)}))
+        self.assertEqual(50, session.artifacts_counts['Cookies'])
+        self.assertEqual('failed in 1 of 2 profiles',
+                         session.describe_artifact_status('Cookies'))
+
+    def test_summary_lists_the_affected_profiles(self):
+        session = self._session(
+            ('/p1', {'Cache': dict(status=ARTIFACT_STATUS_FAILED)}),
+            ('/p2', {'Cache': dict(status=ARTIFACT_STATUS_FAILED)}))
+        self.assertEqual({'Cache': {ARTIFACT_STATUS_FAILED: ['/p1', '/p2']}},
+                         session.artifact_status_summary())
+
+    def test_single_profile_status_is_described_without_a_profile_count(self):
+        session = self._session(('/p1', {'Cache': dict(status=ARTIFACT_STATUS_SKIPPED)}))
+        self.assertEqual('skipped', session.describe_artifact_status('Cache'))
+
+    def test_artifact_with_no_status_describes_as_none(self):
+        session = self._session(('/p1', {'History': dict(count=10)}))
+        self.assertIsNone(session.describe_artifact_status('History'))
+
+    def test_labels_merge_across_profiles(self):
+        session = self._session(
+            ('/p1', {'History': dict(count=1, label='URL records')}),
+            ('/p2', {'Cookies': dict(count=2, label='Cookie records')}))
+        self.assertEqual({'History': 'URL records', 'Cookies': 'Cookie records'},
+                         session.artifacts_display)
+
+
+class TestParsersDoNotNameArtifacts(unittest.TestCase):
+    """The single-writer invariant, checked against the source.
+
+    Every count/label/status key mismatch this design replaced came from a parser
+    naming an artifact independently of the driver. If a parser starts writing into
+    the result store again, that whole class of bug comes back.
+    """
+
+    BROWSER_MODULES = ('chrome', 'firefox')
+
+    STORE_ATTRS = ('artifacts_counts', 'artifacts_display', 'artifacts_status',
+                   'artifact_results')
+
+    def _direct_writes(self, module_name):
+        import ast
+        import importlib
+        import inspect
+
+        module = importlib.import_module(f'pyhindsight.browsers.{module_name}')
+        source = inspect.getsource(module)
+        offenders = []
+        for node in ast.walk(ast.parse(source)):
+            if isinstance(node, ast.Assign) and len(node.targets) == 1:
                 target = node.targets[0]
-                key = ast.get_source_segment(source, target.slice)
-                is_status = isinstance(node.value.value, str) if isinstance(
-                    node.value, ast.Constant) else False
-                (failure_keys if is_status else count_keys).add(key)
-        self.assertEqual({'database'}, failure_keys - count_keys)
+                if (isinstance(target, ast.Subscript)
+                        and isinstance(target.value, ast.Attribute)
+                        and target.value.attr in self.STORE_ATTRS):
+                    offenders.append(f'{module_name} line {node.lineno}: '
+                                     f'writes {target.value.attr}[...] directly')
+        return offenders
+
+    def test_no_parser_writes_the_result_store_directly(self):
+        offenders = []
+        for module_name in self.BROWSER_MODULES:
+            offenders.extend(self._direct_writes(module_name))
+        self.assertEqual([], offenders, '\n' + '\n'.join(offenders))
+
+    def test_parsers_return_counts_instead(self):
+        # Guard against the check above passing because the parsers stopped producing
+        # counts at all. Asserts on a boolean, not the source, so a failure message
+        # stays readable.
+        import ast
+        import importlib
+        import inspect
+        for module_name in self.BROWSER_MODULES:
+            module = importlib.import_module(f'pyhindsight.browsers.{module_name}')
+            returns = sum(
+                1 for node in ast.walk(ast.parse(inspect.getsource(module)))
+                if isinstance(node, ast.Return) and node.value is not None)
+            self.assertGreater(returns, 20,
+                               f'{module_name} has only {returns} value-returning '
+                               f'statements; parsers should be returning counts')
 
 
 if __name__ == '__main__':

--- a/tests/test_chrome_robustness.py
+++ b/tests/test_chrome_robustness.py
@@ -1,0 +1,94 @@
+import json
+import os
+import pathlib
+import tempfile
+import unittest
+
+from pyhindsight.browsers.chrome import Chrome
+
+
+class TestExtensionVersionDirectories(unittest.TestCase):
+    """A malformed version directory must not abort the whole Extensions parse.
+
+    Version directories are named `<version>_<n>`, and the newest is picked by sorting
+    on the numeric components. A directory whose name has a non-numeric component (a
+    stray folder, a beta build) used to raise ValueError inside the sort key, which
+    took down the entire parse rather than that one extension.
+    """
+
+    def _extension(self, tmp, versions):
+        ext = pathlib.Path(tmp, 'abcdefghijklmnopabcdefghijklmnop')
+        for name, manifest in versions.items():
+            version_dir = ext / name
+            version_dir.mkdir(parents=True)
+            (version_dir / 'manifest.json').write_text(
+                json.dumps(manifest), encoding='utf-8')
+        return ext
+
+    def test_a_non_numeric_version_directory_does_not_raise(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ext = self._extension(tmp, {'beta.x_0': {'name': 'Odd', 'version': 'beta'}})
+            manifest, version = Chrome.load_extension_manifest(ext)
+            self.assertEqual('Odd', manifest['name'])
+
+    def test_a_real_version_is_preferred_over_a_malformed_one(self):
+        # The sort runs newest-first, so a malformed name must rank last rather than
+        # being mistaken for the newest version.
+        with tempfile.TemporaryDirectory() as tmp:
+            ext = self._extension(tmp, {
+                '1.2.3_0': {'name': 'Good', 'version': '1.2.3'},
+                'beta.x_0': {'name': 'Odd', 'version': 'beta'},
+            })
+            manifest, version = Chrome.load_extension_manifest(ext)
+            self.assertEqual('Good', manifest['name'])
+            self.assertEqual('1.2.3_0', version)
+
+    def test_highest_numeric_version_still_wins(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ext = self._extension(tmp, {
+                '1.2.3_0': {'name': 'Old', 'version': '1.2.3'},
+                '1.10.0_0': {'name': 'New', 'version': '1.10.0'},
+            })
+            manifest, version = Chrome.load_extension_manifest(ext)
+            # 10 > 2 numerically, which is the reason for the numeric sort in the
+            # first place (a string sort would pick 1.2.3).
+            self.assertEqual('New', manifest['name'])
+
+    def test_missing_manifest_returns_none_rather_than_raising(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ext = pathlib.Path(tmp, 'abcdefghijklmnopabcdefghijklmnop')
+            (ext / '1.0.0_0').mkdir(parents=True)
+            manifest, version = Chrome.load_extension_manifest(ext)
+            self.assertIsNone(manifest)
+
+
+class TestFileSystemOrphanedChildRecords(unittest.TestCase):
+    """A CHILD_OF entry can name a file_id whose own record was deleted.
+
+    Deleted file_id records are skipped when `backing_files` is built, so the lookup
+    for such an entry used to raise KeyError and abort the entire File System parse.
+    The node is still worth keeping -- its name and logical path are recoverable even
+    though the backing-file metadata is not.
+    """
+
+    def test_the_lookup_is_guarded(self):
+        import ast
+        import inspect
+        source = inspect.getsource(Chrome.get_file_system)
+        tree = ast.parse(source.lstrip().replace('\n    ', '\n'))
+        unguarded = []
+        for node in ast.walk(tree):
+            # backing_files[...] as a *load* is the unguarded form; .get() is fine.
+            if (isinstance(node, ast.Subscript)
+                    and isinstance(node.value, ast.Name)
+                    and node.value.id == 'backing_files'
+                    and isinstance(node.ctx, ast.Load)):
+                unguarded.append(node.lineno)
+        self.assertEqual(
+            [], unguarded,
+            'backing_files must be read with .get(); a CHILD_OF entry pointing at a '
+            f'deleted file_id would raise KeyError (lines {unguarded})')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,93 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FIXTURE = os.path.join('tests', 'fixtures', 'firefox')
+
+
+CHROME_FIXTURE = os.path.join('tests', 'fixtures', 'profiles', '60')
+
+
+def run_hindsight(*args, output_dir, profile=FIXTURE):
+    """Run the CLI the way a user does."""
+    return subprocess.run(
+        [sys.executable, 'hindsight.py', '-i', profile,
+         '-o', os.path.join(output_dir, 'out'),
+         '-l', os.path.join(output_dir, 'hindsight.log'),
+         '--temp_dir', os.path.join(output_dir, 'temp'), *args],
+        cwd=REPO_ROOT, capture_output=True, text=True, timeout=300)
+
+
+class TestCommandLineRuns(unittest.TestCase):
+    """End-to-end smoke tests for the CLI itself.
+
+    The unit tests exercise AnalysisSession and the browsers directly, so nothing
+    covered `hindsight.py` -- and a rename of one AnalysisSession method got all the
+    way through a green suite and a real parse before dying at the very last step, in
+    the output summary. Anything that reaches the user through the CLI needs at least
+    one test that actually starts the CLI.
+    """
+
+    def test_a_plain_run_completes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_hindsight('-f', 'jsonl', output_dir=tmp)
+            self.assertEqual(0, result.returncode,
+                             f'stdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+            self.assertNotIn('Traceback', result.stdout + result.stderr)
+            out = os.path.join(tmp, 'out.jsonl')
+            self.assertTrue(os.path.exists(out))
+            with open(out, encoding='utf-8') as f:
+                records = [json.loads(line) for line in f if line.strip()]
+            self.assertTrue(records)
+
+    def test_every_output_format_completes(self):
+        for fmt in ('jsonl', 'sqlite', 'xlsx'):
+            with self.subTest(fmt=fmt), tempfile.TemporaryDirectory() as tmp:
+                result = run_hindsight('-f', fmt, output_dir=tmp)
+                self.assertEqual(0, result.returncode,
+                                 f'{fmt} stderr:\n{result.stderr}')
+                self.assertTrue(os.path.exists(os.path.join(tmp, f'out.{fmt}')))
+
+    def test_a_run_with_unparsed_artifacts_completes(self):
+        # The summary row for unparsed artifacts is only built when something went
+        # unparsed, so a clean run never reaches that code. Skipping an artifact is the
+        # cheapest way to make the run report one.
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_hindsight('-f', 'jsonl', '--skip', 'cookies', output_dir=tmp)
+            self.assertEqual(0, result.returncode,
+                             f'stdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+            self.assertNotIn('Traceback', result.stdout + result.stderr)
+
+    def test_artifact_selection_reaches_the_output(self):
+        # Run against a Chrome profile: Firefox history and downloads never reach JSONL
+        # at all (HindsightEncoder has no branch for their classes), which is a separate
+        # known gap and would mask what this test is actually checking.
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_hindsight('-f', 'jsonl', '--only', 'history',
+                                   output_dir=tmp, profile=CHROME_FIXTURE)
+            self.assertEqual(0, result.returncode, result.stderr)
+            with open(os.path.join(tmp, 'out.jsonl'), encoding='utf-8') as f:
+                types = {json.loads(line).get('data_type') for line in f if line.strip()}
+            self.assertTrue(types, 'no records written')
+            self.assertTrue(all('history' in t for t in types), types)
+
+    def test_list_artifacts_needs_no_input_and_exits_cleanly(self):
+        result = subprocess.run(
+            [sys.executable, 'hindsight.py', '--list-artifacts'],
+            cwd=REPO_ROOT, capture_output=True, text=True, timeout=120)
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn('history', result.stdout)
+
+    def test_an_unknown_artifact_name_fails_loudly(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_hindsight('--only', 'notanartifact', output_dir=tmp)
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn('Unknown artifact', result.stdout + result.stderr)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_firefox_cache2.py
+++ b/tests/test_firefox_cache2.py
@@ -12,8 +12,6 @@ CACHE_DIR = os.path.join(FIXTURE_DIR, 'cache2', 'entries')
 def _make_firefox():
     ff = Firefox(FIXTURE_DIR, no_copy=True, temp_dir=None,
                  timezone=datetime.timezone.utc)
-    ff.artifacts_counts = {}
-    ff.artifacts_display = {}
     ff.parsed_artifacts = []
     ff.parsed_storage = []
     ff.preferences = []
@@ -67,9 +65,9 @@ class TestFirefoxCache2(unittest.TestCase):
 
     def test_get_cache_emits_cacheitem(self):
         ff = _make_firefox()
-        ff.get_cache(CACHE_DIR)
+        reported = ff.get_cache(CACHE_DIR)
 
-        self.assertEqual(ff.artifacts_counts.get('Cache'), 1)
+        self.assertEqual(reported, 1)
         item = ff.parsed_artifacts[0]
         self.assertEqual(item.row_type, 'cache')
         self.assertEqual(item.url,

--- a/tests/test_firefox_cookies.py
+++ b/tests/test_firefox_cookies.py
@@ -12,8 +12,6 @@ REF_DT = datetime.datetime(2024, 1, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
 def _make_firefox():
     ff = Firefox(FIXTURE_DIR, no_copy=True, temp_dir=None,
                  timezone=datetime.timezone.utc)
-    ff.artifacts_counts = {}
-    ff.artifacts_display = {}
     ff.parsed_artifacts = []
     ff.parsed_storage = []
     ff.preferences = []
@@ -23,11 +21,11 @@ def _make_firefox():
 class TestFirefoxCookies(unittest.TestCase):
     def test_get_cookies_count(self):
         ff = _make_firefox()
-        ff.get_cookies(FIXTURE_DIR, 'cookies.sqlite')
+        reported = ff.get_cookies(FIXTURE_DIR, 'cookies.sqlite')
 
         # 2 cookies, only the persistent one has a distinct lastAccessed,
         # so we expect 2 created + 1 accessed = 3 rows.
-        self.assertEqual(ff.artifacts_counts.get('Cookies'), 3)
+        self.assertEqual(reported, 3)
 
         created = [a for a in ff.parsed_artifacts
                    if a.row_type == 'cookie (created)']
@@ -38,7 +36,7 @@ class TestFirefoxCookies(unittest.TestCase):
 
     def test_persistent_cookie_attributes(self):
         ff = _make_firefox()
-        ff.get_cookies(FIXTURE_DIR, 'cookies.sqlite')
+        reported = ff.get_cookies(FIXTURE_DIR, 'cookies.sqlite')
 
         wiki = [a for a in ff.parsed_artifacts
                 if a.name == 'WMF-Last-Access' and a.row_type == 'cookie (created)']
@@ -54,7 +52,7 @@ class TestFirefoxCookies(unittest.TestCase):
 
     def test_session_cookie_no_expiry(self):
         ff = _make_firefox()
-        ff.get_cookies(FIXTURE_DIR, 'cookies.sqlite')
+        reported = ff.get_cookies(FIXTURE_DIR, 'cookies.sqlite')
 
         session = [a for a in ff.parsed_artifacts
                    if a.name == 'session' and a.row_type == 'cookie (created)']

--- a/tests/test_firefox_downloads.py
+++ b/tests/test_firefox_downloads.py
@@ -11,8 +11,6 @@ FIXTURE_DIR = os.path.join('tests', 'fixtures', 'firefox')
 def _make_firefox():
     ff = Firefox(FIXTURE_DIR, no_copy=True, temp_dir=None,
                  timezone=datetime.timezone.utc)
-    ff.artifacts_counts = {}
-    ff.artifacts_display = {}
     ff.parsed_artifacts = []
     ff.parsed_storage = []
     ff.preferences = []
@@ -23,13 +21,13 @@ class TestFirefoxDownloads(unittest.TestCase):
 
     def test_get_downloads_count(self):
         ff = _make_firefox()
-        ff.get_downloads(FIXTURE_DIR, 'places.sqlite')
-        self.assertEqual(ff.artifacts_counts.get('places.sqlite_downloads'), 1)
+        reported = ff.get_downloads(FIXTURE_DIR, 'places.sqlite')
+        self.assertEqual(reported, 1)
         self.assertEqual(len(ff.parsed_artifacts), 1)
 
     def test_download_fields(self):
         ff = _make_firefox()
-        ff.get_downloads(FIXTURE_DIR, 'places.sqlite')
+        reported = ff.get_downloads(FIXTURE_DIR, 'places.sqlite')
 
         dl = ff.parsed_artifacts[0]
         self.assertEqual(dl.row_type, 'download')

--- a/tests/test_firefox_form_history.py
+++ b/tests/test_firefox_form_history.py
@@ -12,8 +12,6 @@ REF_DT = datetime.datetime(2024, 1, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
 def _make_firefox():
     ff = Firefox(FIXTURE_DIR, no_copy=True, temp_dir=None,
                  timezone=datetime.timezone.utc)
-    ff.artifacts_counts = {}
-    ff.artifacts_display = {}
     ff.parsed_artifacts = []
     ff.parsed_storage = []
     ff.preferences = []
@@ -23,14 +21,14 @@ def _make_firefox():
 class TestFirefoxFormHistory(unittest.TestCase):
     def test_form_history_count(self):
         ff = _make_firefox()
-        ff.get_form_history(FIXTURE_DIR, 'formhistory.sqlite')
+        reported = ff.get_form_history(FIXTURE_DIR, 'formhistory.sqlite')
         # Two saved form fields in the fixture.
-        self.assertEqual(ff.artifacts_counts.get('formhistory.sqlite'), 2)
+        self.assertEqual(reported, 2)
         self.assertEqual(len(ff.parsed_artifacts), 2)
 
     def test_email_field(self):
         ff = _make_firefox()
-        ff.get_form_history(FIXTURE_DIR, 'formhistory.sqlite')
+        reported = ff.get_form_history(FIXTURE_DIR, 'formhistory.sqlite')
 
         email = [a for a in ff.parsed_artifacts if a.name == 'email']
         self.assertEqual(len(email), 1)
@@ -42,7 +40,7 @@ class TestFirefoxFormHistory(unittest.TestCase):
 
     def test_searchbar_field(self):
         ff = _make_firefox()
-        ff.get_form_history(FIXTURE_DIR, 'formhistory.sqlite')
+        reported = ff.get_form_history(FIXTURE_DIR, 'formhistory.sqlite')
 
         sb = [a for a in ff.parsed_artifacts if a.name == 'searchbar-history']
         self.assertEqual(len(sb), 1)

--- a/tests/test_firefox_history.py
+++ b/tests/test_firefox_history.py
@@ -12,8 +12,6 @@ REF_DT = datetime.datetime(2024, 1, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
 def _make_firefox():
     ff = Firefox(FIXTURE_DIR, no_copy=True, temp_dir=None,
                  timezone=datetime.timezone.utc)
-    ff.artifacts_counts = {}
-    ff.artifacts_display = {}
     ff.parsed_artifacts = []
     ff.parsed_storage = []
     ff.preferences = []
@@ -24,10 +22,10 @@ class TestFirefoxHistory(unittest.TestCase):
 
     def test_get_history(self):
         ff = _make_firefox()
-        ff.get_history(FIXTURE_DIR, 'places.sqlite')
+        reported = ff.get_history(FIXTURE_DIR, 'places.sqlite')
 
         self.assertEqual(len(ff.parsed_artifacts), 3)
-        self.assertEqual(ff.artifacts_counts.get('places.sqlite'), 3)
+        self.assertEqual(reported, 3)
 
         wiki = [a for a in ff.parsed_artifacts
                 if a.url == 'https://en.wikipedia.org/wiki/Computer_forensics']
@@ -40,9 +38,9 @@ class TestFirefoxHistory(unittest.TestCase):
 
     def test_get_bookmarks(self):
         ff = _make_firefox()
-        ff.get_bookmarks(FIXTURE_DIR, 'places.sqlite')
+        reported = ff.get_bookmarks(FIXTURE_DIR, 'places.sqlite')
 
-        self.assertEqual(ff.artifacts_counts.get('Bookmarks'), 2)
+        self.assertEqual(reported, 2)
         bookmark_urls = [a for a in ff.parsed_artifacts if a.row_type == 'bookmark']
         folders = [a for a in ff.parsed_artifacts if a.row_type == 'bookmark folder']
         self.assertEqual(len(bookmark_urls), 1)
@@ -55,7 +53,7 @@ class TestFirefoxHistory(unittest.TestCase):
 
     def test_determine_version(self):
         ff = _make_firefox()
-        ff.get_history(FIXTURE_DIR, 'places.sqlite')
+        reported = ff.get_history(FIXTURE_DIR, 'places.sqlite')
         ff.determine_version(FIXTURE_DIR, 'places.sqlite')
 
         self.assertIn(80, ff.version)

--- a/tests/test_firefox_misc.py
+++ b/tests/test_firefox_misc.py
@@ -11,8 +11,6 @@ FIXTURE_DIR = os.path.join('tests', 'fixtures', 'firefox')
 def _make_firefox():
     ff = Firefox(FIXTURE_DIR, no_copy=True, temp_dir=None,
                  timezone=datetime.timezone.utc)
-    ff.artifacts_counts = {}
-    ff.artifacts_display = {}
     ff.parsed_artifacts = []
     ff.parsed_storage = []
     ff.preferences = []
@@ -22,9 +20,9 @@ def _make_firefox():
 class TestFirefoxPermissions(unittest.TestCase):
     def test_count_and_friendly_labels(self):
         ff = _make_firefox()
-        ff.get_permissions(FIXTURE_DIR, 'permissions.sqlite')
+        reported = ff.get_permissions(FIXTURE_DIR, 'permissions.sqlite')
 
-        self.assertEqual(ff.artifacts_counts.get('Permissions'), 2)
+        self.assertEqual(reported, 2)
 
         rows = {(a.url, a.key): a for a in ff.parsed_artifacts}
         wiki = rows[('https://en.wikipedia.org', 'desktop-notification')]
@@ -39,13 +37,13 @@ class TestFirefoxPermissions(unittest.TestCase):
 class TestFirefoxPrefs(unittest.TestCase):
     def test_prefs_count(self):
         ff = _make_firefox()
-        ff.get_preferences(FIXTURE_DIR, 'prefs.js')
+        reported = ff.get_preferences(FIXTURE_DIR, 'prefs.js')
         # Fixture has 10 user_pref lines; the parser also emits curated rows.
-        self.assertGreaterEqual(ff.artifacts_counts.get('Preferences'), 10)
+        self.assertGreaterEqual(reported, 10)
 
     def test_homepage_and_download_dir_surface(self):
         ff = _make_firefox()
-        ff.get_preferences(FIXTURE_DIR, 'prefs.js')
+        reported = ff.get_preferences(FIXTURE_DIR, 'prefs.js')
 
         pref_rows = ff.preferences[0]['data']
         by_name = {p['name']: p['value'] for p in pref_rows if p.get('name')}
@@ -60,10 +58,10 @@ class TestFirefoxPrefs(unittest.TestCase):
 class TestFirefoxLogins(unittest.TestCase):
     def test_login_emits_three_timestamp_rows(self):
         ff = _make_firefox()
-        ff.get_logins(FIXTURE_DIR, 'logins.json')
+        reported = ff.get_logins(FIXTURE_DIR, 'logins.json')
 
         # One credential, three distinct timestamps -> three rows.
-        self.assertEqual(ff.artifacts_counts.get('Logins'), 3)
+        self.assertEqual(reported, 3)
 
         row_types = sorted(a.row_type for a in ff.parsed_artifacts)
         self.assertEqual(row_types, [
@@ -79,9 +77,9 @@ class TestFirefoxLogins(unittest.TestCase):
 class TestFirefoxExtensions(unittest.TestCase):
     def test_one_extension_with_signed_state_label(self):
         ff = _make_firefox()
-        ff.get_extensions(FIXTURE_DIR, 'extensions.json')
+        reported = ff.get_extensions(FIXTURE_DIR, 'extensions.json')
 
-        self.assertEqual(ff.artifacts_counts.get('Extensions'), 1)
+        self.assertEqual(reported, 1)
         ext = ff.installed_extensions['data'][0]
         self.assertEqual(ext.ext_id, 'uBlock0@raymondhill.net')
         self.assertEqual(ext.name, 'uBlock Origin')

--- a/tests/test_firefox_storage.py
+++ b/tests/test_firefox_storage.py
@@ -12,8 +12,6 @@ FIXTURE_DIR = os.path.join('tests', 'fixtures', 'firefox')
 def _make_firefox():
     ff = Firefox(FIXTURE_DIR, no_copy=True, temp_dir=None,
                  timezone=datetime.timezone.utc)
-    ff.artifacts_counts = {}
-    ff.artifacts_display = {}
     ff.parsed_artifacts = []
     ff.parsed_storage = []
     ff.preferences = []
@@ -195,10 +193,13 @@ class TestIDBKeyDecoder(unittest.TestCase):
 class TestLocalStorage(unittest.TestCase):
     def test_walk_fixture_storage_directory(self):
         ff = _make_firefox()
-        ff.get_local_storage(FIXTURE_DIR)
+        reported = ff.get_local_storage(FIXTURE_DIR)
 
         # One origin, two key/value pairs (one raw, one snappy-compressed).
-        self.assertEqual(ff.artifacts_counts.get('Local Storage'), 2)
+        # get_local_storage reports partial failures, so it returns a ParseResult;
+        # the count is the first field.
+        self.assertEqual(reported.count, 2)
+        self.assertFalse(reported.is_partial)
         self.assertEqual(len(ff.parsed_storage), 2)
 
         by_key = {item.key: item for item in ff.parsed_storage}

--- a/tests/test_partial_results.py
+++ b/tests/test_partial_results.py
@@ -1,0 +1,288 @@
+import io
+import logging
+import re
+import unittest
+
+import rich.console
+
+from pyhindsight.browsers.webbrowser import (
+    ARTIFACT_STATUS_PARTIAL,
+    ParseFailures,
+    ParseResult,
+    ProcessingDisplay,
+    WebBrowser,
+)
+
+
+class _CapturingHandler(logging.Handler):
+    def __init__(self):
+        super().__init__(level=logging.DEBUG)
+        self.messages = []
+
+    def emit(self, record):
+        self.messages.append(record.getMessage())
+
+
+class _LogCapture:
+    """Capture everything pyhindsight.browsers.webbrowser logs during a block."""
+
+    def __enter__(self):
+        self.handler = _CapturingHandler()
+        self.logger = logging.getLogger('pyhindsight.browsers.webbrowser')
+        self.previous_level = self.logger.level
+        self.logger.addHandler(self.handler)
+        self.logger.setLevel(logging.DEBUG)
+        return self
+
+    def __exit__(self, *exc):
+        self.logger.removeHandler(self.handler)
+        self.logger.setLevel(self.previous_level)
+        return False
+
+    @property
+    def messages(self):
+        return self.handler.messages
+
+
+class TestParseFailures(unittest.TestCase):
+    """The collector counts what it logs, so the two can't disagree."""
+
+    def test_result_counts_match_what_was_recorded(self):
+        unparsed = ParseFailures('Local Storage')
+        unparsed.source('a/ls/data.sqlite', 'could not be opened')
+        unparsed.source('b/ls/data.sqlite', 'corrupt header')
+        unparsed.record('c/key1', 'decode failed')
+        result = unparsed.result(412)
+        self.assertEqual(ParseResult(412, 2, 1), result)
+
+    def test_every_failure_is_logged_as_it_happens(self):
+        with _LogCapture() as captured:
+            unparsed = ParseFailures('Local Storage')
+            unparsed.source('a/ls/data.sqlite', 'could not be opened')
+            unparsed.record('c/key1', 'decode failed')
+        joined = '\n'.join(captured.messages)
+        self.assertIn('a/ls/data.sqlite', joined)
+        self.assertIn('could not be opened', joined)
+        self.assertIn('c/key1', joined)
+        self.assertIn('decode failed', joined)
+
+    def test_detail_line_count_equals_the_reported_totals(self):
+        # The requirement: what the log enumerates and what the run reports are the
+        # same numbers, so a reader can reconcile the two.
+        with _LogCapture() as captured:
+            unparsed = ParseFailures('IndexedDB')
+            for i in range(3):
+                unparsed.source(f'db{i}.sqlite', 'unreadable')
+            for i in range(7):
+                unparsed.record(f'db9.sqlite:key{i}', 'decode failed')
+            result = unparsed.result(100)
+        sources = [m for m in captured.messages if m.startswith(' - Unparsed source')]
+        records = [m for m in captured.messages if m.startswith(' - Unparsed record')]
+        self.assertEqual(len(sources), result.unparsed_sources)
+        self.assertEqual(len(records), result.unparsed_records)
+
+    def test_the_same_failure_is_only_counted_once(self):
+        # Some parsers read a file in more than one pass; a truncated file fails
+        # identically in each. That is one unparsed source, not one per pass.
+        unparsed = ParseFailures('Sessions')
+        unparsed.source('Session_13400', 'truncated')
+        unparsed.source('Session_13400', 'truncated')
+        self.assertEqual(1, unparsed.result(5).unparsed_sources)
+
+    def test_distinct_failures_on_one_source_are_both_counted(self):
+        unparsed = ParseFailures('Sessions')
+        unparsed.source('Session_13400', 'truncated')
+        unparsed.source('Session_13400', 'header unreadable')
+        self.assertEqual(2, unparsed.result(5).unparsed_sources)
+
+    def test_a_repeated_failure_is_only_logged_once(self):
+        with _LogCapture() as captured:
+            unparsed = ParseFailures('Sessions')
+            unparsed.source('Session_13400', 'truncated')
+            unparsed.source('Session_13400', 'truncated')
+        lines = [m for m in captured.messages if 'Unparsed source' in m]
+        self.assertEqual(1, len(lines))
+
+    def test_a_clean_parse_is_not_partial(self):
+        self.assertFalse(ParseFailures('X').result(10).is_partial)
+        self.assertTrue(ParseFailures('X').result(10)._replace(unparsed_records=1).is_partial)
+
+
+class TestDeliveryReconciliation(unittest.TestCase):
+    """A count alone cannot reveal that the records behind it were dropped.
+
+    The count is derived from a list the parser built; the records reach output through
+    a separate `extend`. When a misplaced return skipped the extend, the reported number
+    stayed correct while 18k records never reached the output -- invisible, because the
+    count was right.
+    """
+
+    def _driver(self):
+        browser = WebBrowser('fixture-profile', 'Chrome')
+        browser.display_version = '999'
+        driver = ProcessingDisplay(browser, ['Group'])
+        driver.console = rich.console.Console(file=io.StringIO(), width=110)
+        return driver
+
+    def _run(self, parser):
+        driver = self._driver()
+        with _LogCapture() as captured:
+            with driver:
+                driver.group('Group')
+                driver.run('Extension State', 'Extension State', parser,
+                           display_value='Extension State records',
+                           artifact='extension-storage')
+        return driver, captured
+
+    def test_a_count_with_no_delivered_records_is_reported(self):
+        # The exact shape of the bug: parse, count, drop.
+        driver, captured = self._run(lambda: 15978)
+        errors = [m for m in captured.messages if 'contributed none' in m]
+        self.assertEqual(1, len(errors), captured.messages)
+        self.assertIn('15978', errors[0])
+
+    def test_a_parser_that_delivers_records_is_not_flagged(self):
+        driver = self._driver()
+
+        def parser():
+            driver.browser.parsed_extension_data.extend([object(), object()])
+            return 2
+
+        with _LogCapture() as captured:
+            with driver:
+                driver.group('Group')
+                driver.run('Extension State', 'Extension State', parser,
+                           display_value='Extension State records',
+                           artifact='extension-storage')
+        self.assertEqual([], [m for m in captured.messages if 'contributed none' in m])
+
+    def test_a_zero_count_is_not_flagged(self):
+        # Parsing nothing and delivering nothing is consistent, not a bug.
+        _, captured = self._run(lambda: 0)
+        self.assertEqual([], [m for m in captured.messages if 'contributed none' in m])
+
+    def test_a_failed_parse_is_not_flagged(self):
+        _, captured = self._run(lambda: None)
+        self.assertEqual([], [m for m in captured.messages if 'contributed none' in m])
+
+    def test_delivery_into_any_collection_counts(self):
+        # Parsers deliver into different collections; growth in any of them satisfies
+        # the invariant (chrome's get_extensions contributes to neither parsed_artifacts
+        # nor parsed_storage, for instance).
+        from pyhindsight.browsers.webbrowser import RESULT_COLLECTIONS
+        self.assertIn('parsed_artifacts', RESULT_COLLECTIONS)
+        self.assertIn('parsed_storage', RESULT_COLLECTIONS)
+        self.assertIn('parsed_extension_data', RESULT_COLLECTIONS)
+        self.assertIn('installed_extensions', RESULT_COLLECTIONS)
+
+    def test_collection_sizes_handles_dict_shaped_collections(self):
+        browser = WebBrowser('p', 'Chrome')
+        browser.installed_extensions = {'data': [1, 2, 3], 'presentation': {}}
+        self.assertEqual(3, browser.collection_sizes()['installed_extensions'])
+
+
+class TestDriverRecordsPartials(unittest.TestCase):
+
+    def _driver(self):
+        browser = WebBrowser('fixture-profile', 'Chrome')
+        browser.display_version = '999'
+        driver = ProcessingDisplay(browser, ['Group'])
+        driver.console = rich.console.Console(file=io.StringIO(), width=110)
+        return driver
+
+    def _run(self, returned):
+        driver = self._driver()
+        with driver:
+            driver.group('Group')
+            driver.run('Local Storage', 'Local Storage', lambda: returned,
+                       display_value='Local Storage records', artifact='local-storage')
+        return driver
+
+    def test_a_plain_int_is_a_clean_count(self):
+        driver = self._run(412)
+        result = driver.browser.artifact_results['Local Storage']
+        self.assertEqual(412, result.count)
+        self.assertIsNone(result.status)
+        self.assertFalse(result.is_partial)
+
+    def test_a_partial_result_records_both_tiers(self):
+        driver = self._run(ParseResult(412, 3, 5))
+        result = driver.browser.artifact_results['Local Storage']
+        self.assertEqual(412, result.count)
+        self.assertEqual(3, result.unparsed_sources)
+        self.assertEqual(5, result.unparsed_records)
+        self.assertEqual(ARTIFACT_STATUS_PARTIAL, result.status)
+
+    def test_a_partial_result_still_reports_its_count(self):
+        # Unlike a failure, a partial parse produced records; the count is real and
+        # must survive, with the caveat attached rather than replacing it.
+        driver = self._run(ParseResult(412, 3, 0))
+        self.assertEqual({'Local Storage': 412}, driver.browser.artifacts_counts)
+
+    def test_a_parse_result_with_no_losses_is_not_marked_partial(self):
+        driver = self._run(ParseResult(412))
+        result = driver.browser.artifact_results['Local Storage']
+        self.assertIsNone(result.status)
+
+    def test_the_logged_summary_matches_the_recorded_result(self):
+        # The driver builds the summary from the record it just wrote, so the totals
+        # in the log are by construction the totals rendered on screen.
+        with _LogCapture() as captured:
+            driver = self._run(ParseResult(412, 3, 5))
+        result = driver.browser.artifact_results['Local Storage']
+        summaries = [m for m in captured.messages if 'parsed' in m and 'unparsed' in m]
+        self.assertEqual(1, len(summaries), captured.messages)
+        found = re.search(r'parsed (\d+); (.+)', summaries[0])
+        self.assertEqual(str(result.count), found.group(1))
+        self.assertEqual(result.describe_unparsed(), found.group(2))
+
+    def test_the_rendered_note_matches_the_recorded_result(self):
+        driver = self._run(ParseResult(412, 3, 5))
+        note = driver.output_groups['Group'][0][2]
+        self.assertEqual('3 sources, 5 records', note.plain)
+
+    def test_only_the_tiers_that_lost_something_are_named(self):
+        self.assertEqual(
+            '5 records', self._run(ParseResult(412, 0, 5)).output_groups['Group'][0][2].plain)
+        self.assertEqual(
+            '3 sources', self._run(ParseResult(412, 3, 0)).output_groups['Group'][0][2].plain)
+
+    def test_sources_are_named_before_records(self):
+        # A source that would not open could have held anything, so it is the finding
+        # that stops the count being usable as a total; it leads.
+        note = self._run(ParseResult(412, 3, 5)).output_groups['Group'][0][2].plain
+        self.assertLess(note.index('source'), note.index('record'))
+
+    def test_unparsed_is_not_written_as_a_subtraction(self):
+        # "412" and "5 records" are two facts about the artifact. A leading minus read
+        # as arithmetic -- as though 5 had been taken off the 412 that was parsed.
+        note = self._run(ParseResult(412, 3, 5)).output_groups['Group'][0][2].plain
+        self.assertFalse(note.startswith('-'), note)
+        self.assertNotIn('-', note)
+
+    def test_a_clean_artifact_has_an_empty_unparsed_cell(self):
+        driver = self._run(412)
+        self.assertIsNone(driver.output_groups['Group'][0][2])
+
+    def test_each_artifact_stays_on_one_row(self):
+        # The unparsed tally rides beside the count instead of adding a row, so an
+        # incomplete artifact doesn't read as two artifacts.
+        driver = self._run(ParseResult(412, 3, 5))
+        lines = [l for l in driver.console.file.getvalue().splitlines()
+                 if 'Local Storage records' in l]
+        self.assertEqual(1, len(lines))
+        self.assertIn('412', lines[0])
+        self.assertIn('3 sources', lines[0])
+        self.assertIn('5 records', lines[0])
+
+    def test_the_unparsed_column_appears_only_when_something_went_unparsed(self):
+        # Present or absent for the whole run, never per group: a column on some groups
+        # and not others gives the tables different widths and they stop lining up.
+        self.assertNotIn('Unparsed', self._run(412).console.file.getvalue())
+        self.assertIn('Unparsed', self._run(ParseResult(412, 3, 5)).console.file.getvalue())
+        # And the parsed column is labelled as such in both cases.
+        self.assertIn('Parsed', self._run(412).console.file.getvalue())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Refactor how get_* functions track how many records they've parsed (or failed to parse). 
- Surface the parsing failures in the TUI
- Better explain in the log why something failed to parse
- Add more tests for all of this