### PR TITLE
Stop output formats silently dropping whole artifacts

### DIFF
--- a/pyhindsight/analysis.py
+++ b/pyhindsight/analysis.py
@@ -142,7 +142,7 @@ class HindsightEncoder(json.JSONEncoder):
             item['data_type'] = 'chrome:history:page_visited'
             item['url_hidden'] = 'true' if item.get('hidden') else 'false'
             if item.get('visit_duration') == 'None':
-                del (item['visit_duration'])
+                item.pop('visit_duration', None)
 
             # .get() throughout: base_encoder drops keys whose value is None, so a page
             # the browser recorded without a title would raise KeyError here -- and that
@@ -165,12 +165,12 @@ class HindsightEncoder(json.JSONEncoder):
             item['data_type'] = 'chrome:history:media_playback'
 
             if item.get('source_title'):
-                item['message'] = f"Watched{item['watch_time']} on {item['source_title']} "\
-                                  f"(ending at {item['position']}/{item.get('media_duration')}) " \
-                                  f"[has_video: {item['has_video']}; has_audio: {item['has_audio']}]"
+                item['message'] = f"Watched{item.get('watch_time')} on {item.get('source_title')} "\
+                                  f"(ending at {item.get('position')}/{item.get('media_duration')}) " \
+                                  f"[has_video: {item.get('has_video')}; has_audio: {item.get('has_audio')}]"
             else:
-                item['message'] = f"Watched{item['watch_time']} on {item['url']} " \
-                                  f"[has_video: {item['has_video']}; has_audio: {item['has_audio']}]"
+                item['message'] = f"Watched{item.get('watch_time')} on {item.get('url')} " \
+                                  f"[has_video: {item.get('has_video')}; has_audio: {item.get('has_audio')}]"
 
             return item
 
@@ -193,8 +193,8 @@ class HindsightEncoder(json.JSONEncoder):
                 item['message'] = f"{item.get('url', '')} ({item.get('title', '')})"
 
             # Serialize page_state as structured JSON for JSONL output
-            if item.get('page_state') and item['page_state'].top_frame:
-                ps = item['page_state']
+            if item.get('page_state') and item.get('page_state').top_frame:
+                ps = item.get('page_state')
                 tf = ps.top_frame
                 ps_dict = {'version': ps.version}
 
@@ -245,9 +245,10 @@ class HindsightEncoder(json.JSONEncoder):
                 ps_dict['top_frame'] = frame_dict
                 item['page_state'] = ps_dict
             elif 'page_state' in item:
-                del item['page_state']
+                item.pop('page_state', None)
 
-            del(item['row_type'], item['name'])
+            for _key in ('row_type', 'name'):
+                item.pop(_key, None)
             return item
 
         if isinstance(obj, WebBrowser.DownloadItem):
@@ -286,27 +287,30 @@ class HindsightEncoder(json.JSONEncoder):
 
             item['data_type'] = 'chrome:cookie:entry'
             item['source_long'] = 'Chrome Cookies'
-            if item['row_type'] == 'cookie (accessed)':
+            if item.get('row_type') == 'cookie (accessed)':
                 item['timestamp_desc'] = 'Last Access Time'
-            elif item['row_type'] == 'cookie (created)':
+            elif item.get('row_type') == 'cookie (created)':
                 item['timestamp_desc'] = 'Creation Time'
-            item['host'] = item['host_key']
-            item['cookie_name'] = item['name']
-            item['data'] = item['value'] if item['value'] != '<encrypted>' else ''
-            item['url'] = item['url'].lstrip('.')
-            item['url'] = f'https://{item["url"]}' if item['secure'] else f'http://{item["url"]}'
+            item['host'] = item.get('host_key')
+            item['cookie_name'] = item.get('name')
+            item['data'] = item.get('value') if item.get('value') != '<encrypted>' else ''
+            # `or ''` rather than just .get(): a cookie row with no host would make
+            # .get() return None and .lstrip() raise, which is the same whole-file
+            # failure as the KeyError, just with a different name.
+            item['url'] = (item.get('url') or '').lstrip('.')
+            item['url'] = f'https://{item["url"]}' if item.get('secure') else f'http://{item["url"]}'
             if item.get('expires_utc') == '1970-01-01T00:00:00+00:00':
-                del(item['expires_utc'])
+                item.pop('expires_utc', None)
             # Convert these from 1/0 to true/false to match Plaso
-            item['secure'] = 'true' if item['secure'] else 'false'
-            item['httponly'] = 'true' if item['httponly'] else 'false'
-            item['persistent'] = 'true' if item['persistent'] else 'false'
+            item['secure'] = 'true' if item.get('secure') else 'false'
+            item['httponly'] = 'true' if item.get('httponly') else 'false'
+            item['persistent'] = 'true' if item.get('persistent') else 'false'
 
             item['message'] = (f'{item["url"]} ({item["cookie_name"]}) Flags: [HTTP only] = {item["httponly"]} '
                                f'[Persistent] = {item["persistent"]}')
 
-            del(item['creation_utc'], item['last_access_utc'], item['row_type'],
-                item['host_key'], item['name'], item['value'])
+            for _key in ('creation_utc', 'last_access_utc', 'row_type', 'host_key', 'name', 'value'):
+                item.pop(_key, None)
             return item
 
         if isinstance(obj, Chrome.AutofillItem):
@@ -331,9 +335,10 @@ class HindsightEncoder(json.JSONEncoder):
             item['data_type'] = 'chrome:bookmark:entry'
             item['source_long'] = 'Chrome Bookmarks'
 
-            item['message'] = f'{item["name"]} ({item["url"]}) bookmarked in folder "{item["parent_folder"]}"'
+            item['message'] = f'{item.get("name")} ({item.get("url")}) bookmarked in folder "{item.get("parent_folder")}"'
 
-            del(item['value'], item['row_type'], item['date_added'])
+            for _key in ('value', 'row_type', 'date_added'):
+                item.pop(_key, None)
             return item
 
         if isinstance(obj, Chrome.BookmarkFolderItem):
@@ -343,9 +348,10 @@ class HindsightEncoder(json.JSONEncoder):
             item['data_type'] = 'chrome:bookmark:folder'
             item['source_long'] = 'Chrome Bookmarks'
 
-            item['message'] = f'"{item["name"]}" bookmark folder created in folder "{item["parent_folder"]}"'
+            item['message'] = f'"{item.get("name")}" bookmark folder created in folder "{item.get("parent_folder")}"'
 
-            del(item['value'], item['row_type'], item['date_added'])
+            for _key in ('value', 'row_type', 'date_added'):
+                item.pop(_key, None)
             return item
 
         if isinstance(obj, Chrome.LocalStorageItem):
@@ -354,13 +360,15 @@ class HindsightEncoder(json.JSONEncoder):
             item['timestamp_desc'] = 'Not a time'
             item['data_type'] = 'chrome:local_storage:entry'
             item['source_long'] = 'Chrome LocalStorage'
-            item['url'] = item['origin'][1:]
+            # `or ''` rather than just .get(): slicing None raises, which fails the
+            # whole JSONL file the same way the KeyError did, only with another name.
+            item['url'] = (item.get('origin') or '')[1:]
             item['state_friendly'] = item.get('state')
             item['state'] = 0 if item.get('state') == 'Deleted' else 1
 
-            item['message'] = f'key: {item["key"]} value: {item["value"]}'
+            item['message'] = f'key: {item.get("key")} value: {item.get("value")}'
 
-            del (item['row_type'])
+            item.pop('row_type', None)
             return item
 
         if isinstance(obj, Chrome.SessionStorageItem):
@@ -369,13 +377,13 @@ class HindsightEncoder(json.JSONEncoder):
             item['timestamp_desc'] = 'Not a time'
             item['data_type'] = 'chrome:session_storage:entry'
             item['source_long'] = 'Chrome Session Storage'
-            item['url'] = item['origin']
+            item['url'] = item.get('origin')
             item['state_friendly'] = item.get('state')
             item['state'] = 0 if item.get('state') == 'Deleted' else 1
 
             item['message'] = f'key: {item.get("key", "")} value: {item.get("value", "")}'
 
-            del (item['row_type'])
+            item.pop('row_type', None)
             return item
 
         if isinstance(obj, Chrome.IndexedDBItem):
@@ -384,7 +392,7 @@ class HindsightEncoder(json.JSONEncoder):
             item['timestamp_desc'] = 'Not a time'
             item['data_type'] = 'chrome:indexeddb:entry'
             item['source_long'] = 'Chrome IndexedDB'
-            item['url'] = item['origin']
+            item['url'] = item.get('origin')
             item['state_friendly'] = item.get('state')
             item['state'] = 0 if item.get('state') == 'Deleted' else 1
 
@@ -394,7 +402,7 @@ class HindsightEncoder(json.JSONEncoder):
                 f'value: {item.get("value", "")}'
             )
 
-            del (item['row_type'])
+            item.pop('row_type', None)
             return item
 
         if isinstance(obj, Chrome.FileSystemItem):
@@ -403,13 +411,13 @@ class HindsightEncoder(json.JSONEncoder):
             item['timestamp_desc'] = 'Not a time'
             item['data_type'] = 'chrome:file_system:entry'
             item['source_long'] = 'Chrome File System'
-            item['url'] = item['origin']
+            item['url'] = item.get('origin')
             item['state_friendly'] = item.get('state')
             item['state'] = 0 if item.get('state') == 'Deleted' else 1
 
-            item['message'] = f'key: {item["key"]} value: {item["value"]}'
+            item['message'] = f'key: {item.get("key")} value: {item.get("value")}'
 
-            del (item['row_type'])
+            item.pop('row_type', None)
             return item
 
         if isinstance(obj, Chrome.LoginItem):
@@ -432,9 +440,10 @@ class HindsightEncoder(json.JSONEncoder):
             item['timestamp_desc'] = 'Update Time'
             item['data_type'] = 'chrome:preferences:entry'
             item['source_long'] = 'Chrome Preferences'
-            item['message'] = f'Updated preference: {item["key"]}: {item["value"]})'
+            item['message'] = f'Updated preference: {item.get("key")}: {item.get("value")})'
 
-            del(item['row_type'], item['name'])
+            for _key in ('row_type', 'name'):
+                item.pop(_key, None)
             return item
 
         if isinstance(obj, Chrome.ExtensionStorageItem):
@@ -453,7 +462,7 @@ class HindsightEncoder(json.JSONEncoder):
                 f'value: {item.get("value", "")}'
             )
 
-            del (item['row_type'])
+            item.pop('row_type', None)
             return item
 
         if isinstance(obj, Chrome.SyncDataItem):
@@ -467,13 +476,13 @@ class HindsightEncoder(json.JSONEncoder):
 
             item['message'] = f'key: {item.get("key", "")} value: {item.get("value", "")}'
 
-            del (item['row_type'])
+            item.pop('row_type', None)
             return item
 
         if isinstance(obj, Chrome.SiteSetting):
             item = HindsightEncoder.base_encoder(obj)
 
-            if item['key'] == 'Status: Deleted':
+            if item.get('key') == 'Status: Deleted':
                 item['timestamp_desc'] = 'Not a time'
             else:
                 item['timestamp_desc'] = 'Update Time'
@@ -481,12 +490,13 @@ class HindsightEncoder(json.JSONEncoder):
             item['data_type'] = 'chrome:site_setting:entry'
             item['source_long'] = 'Chrome Site Settings'
 
-            if item['key'] == 'Status: Deleted':
+            if item.get('key') == 'Status: Deleted':
                 item['message'] = 'Updated site setting (recovered deleted record)'
             else:
-                item['message'] = f'Updated site setting: {item["key"]}: {item["value"]})'
+                item['message'] = f'Updated site setting: {item.get("key")}: {item.get("value")})'
 
-            del(item['row_type'], item['name'])
+            for _key in ('row_type', 'name'):
+                item.pop(_key, None)
             return item
 
         if isinstance(obj, WebBrowser.ServiceWorkerItem):
@@ -510,9 +520,9 @@ class HindsightEncoder(json.JSONEncoder):
             # all, which is why it is appended rather than embedded.
             message = f"resource {item.get('resource_id', '')}"
             if item.get('resource_state'):
-                message += f" ({item['resource_state']})"
+                message += f" ({item.get('resource_state')})"
             if item.get('origin'):
-                message += f" for {item['origin']}"
+                message += f" for {item.get('origin')}"
             item['message'] = message
             item.pop('row_type', None)
             return item
@@ -560,10 +570,10 @@ class HindsightEncoder(json.JSONEncoder):
                 'Last Visit Time' if obj.timestamp is not None else 'Not a time'
             item['data_type'] = 'chrome:cache:entry'
             item['source_long'] = 'Chrome Cache'
-            item['original_url'] = item['url']
-            item['cache_type'] = item['row_type']
+            item['original_url'] = item.get('url')
+            item['cache_type'] = item.get('row_type')
 
-            if item['data_summary'] == '<no data>':
+            if item.get('data_summary') == '<no data>':
                 item['cached_state'] = 'Evicted'
             else:
                 item['cached_state'] = 'Cached'
@@ -571,9 +581,9 @@ class HindsightEncoder(json.JSONEncoder):
             item['message'] = f'Original URL: {item["original_url"]}'
 
             if item.get('data'):
-                del item['data']
+                item.pop('data', None)
 
-            del item['row_type']
+            item.pop('row_type', None)
             return item
 
         # No branch matched. Emitting the record generically beats dropping it: a

--- a/pyhindsight/analysis.py
+++ b/pyhindsight/analysis.py
@@ -2,6 +2,7 @@ import datetime
 import importlib
 import collections
 import json
+import re
 import logging
 import os
 import sqlite3
@@ -67,6 +68,40 @@ class HindsightEncoder(json.JSONEncoder):
     Timesketch (https://github.com/google/timesketch/).
     """
 
+    _warned_unhandled = set()
+
+    @classmethod
+    def warn_unhandled(cls, class_name, data_type):
+        """Warn once that a record class has no encoder branch of its own.
+
+        The record is still written, with fields as-is and a data_type derived from its
+        row_type, but nobody chose that shape deliberately -- so it says so rather than
+        looking like a considered format.
+        """
+        if class_name in cls._warned_unhandled:
+            return
+        cls._warned_unhandled.add(class_name)
+        log.warning(
+            f'{class_name} has no HindsightEncoder branch; its records are written '
+            f'generically as "{data_type}". Add a branch to control their shape.')
+
+    @staticmethod
+    def promote_timestamp(item, field, description):
+        """Use `field` as the record's datetime when it holds one.
+
+        These records carry their time in a field of their own rather than in
+        `timestamp`, so without this they all take base_encoder's epoch placeholder and
+        land in 1970. Where the field is absent the placeholder stands, labelled the way
+        the other timeless records are rather than asserting a 1970 event.
+        """
+        value = item.get(field)
+        if value:
+            item['datetime'] = value
+            item['timestamp_desc'] = description
+        else:
+            item['timestamp_desc'] = 'Not a time'
+        return item
+
     @staticmethod
     def base_encoder(history_item):
         item = {'source_short': 'WEBHIST', 'source_long': 'Chrome History',
@@ -100,19 +135,27 @@ class HindsightEncoder(json.JSONEncoder):
         return item
 
     def default(self, obj):
-        if isinstance(obj, Chrome.URLItem):
+        if isinstance(obj, WebBrowser.URLItem):
             item = HindsightEncoder.base_encoder(obj)
 
             item['timestamp_desc'] = 'Last Visited Time'
             item['data_type'] = 'chrome:history:page_visited'
-            item['url_hidden'] = 'true' if item['hidden'] else 'false'
+            item['url_hidden'] = 'true' if item.get('hidden') else 'false'
             if item.get('visit_duration') == 'None':
                 del (item['visit_duration'])
 
-            item['message'] = f"{item['url']} ({item['title']}) [count: {item['visit_count']}]"
+            # .get() throughout: base_encoder drops keys whose value is None, so a page
+            # the browser recorded without a title would raise KeyError here -- and that
+            # escapes write_jsonl_record and aborts the whole file, losing every
+            # remaining record rather than the one.
+            item['message'] = f"{item.get('url')} ({item.get('title')}) " \
+                              f"[count: {item.get('visit_count')}]"
 
-            del(item['name'], item['row_type'], item['visit_time'],
-                item['last_visit_time'], item['hidden'])
+            # base_encoder drops keys whose value is None, so these are only present on
+            # a browser that recorded them; deleting them unconditionally would raise on
+            # one that didn't.
+            for key in ('name', 'row_type', 'visit_time', 'last_visit_time', 'hidden'):
+                item.pop(key, None)
             return item
 
         if isinstance(obj, Chrome.MediaItem):
@@ -207,18 +250,23 @@ class HindsightEncoder(json.JSONEncoder):
             del(item['row_type'], item['name'])
             return item
 
-        if isinstance(obj, Chrome.DownloadItem):
+        if isinstance(obj, WebBrowser.DownloadItem):
             item = HindsightEncoder.base_encoder(obj)
 
             item['timestamp_desc'] = 'Last Access Time' \
                 if '(opened)' in (getattr(obj, 'row_type', '') or '') else 'File Downloaded'
             item['data_type'] = 'chrome:history:file_downloaded'
 
-            item['message'] = f"{item['url']} " \
-                              f"({item['full_path'] if item.get('full_path') else item.get('target_path')}). " \
-                              f"Received {item['received_bytes']}/{item['total_bytes']} bytes"
+            item['message'] = f"{item.get('url')} " \
+                              f"({item.get('full_path') or item.get('target_path')})"
+            # Firefox's places.sqlite has no byte counts, and base_encoder drops None,
+            # so this is only appended when the browser actually recorded them.
+            if item.get('received_bytes') is not None or item.get('total_bytes') is not None:
+                item['message'] += (f". Received {item.get('received_bytes')}"
+                                    f"/{item.get('total_bytes')} bytes")
 
-            del(item['row_type'], item['start_time'])
+            for key in ('row_type', 'start_time'):
+                item.pop(key, None)
             return item
 
         if isinstance(obj, Chrome.BrowserExtension):
@@ -267,12 +315,13 @@ class HindsightEncoder(json.JSONEncoder):
             item['timestamp_desc'] = 'Used Time'
             item['data_type'] = 'chrome:autofill:entry'
             item['source_long'] = 'Chrome Autofill'
-            item['usage_count'] = item['count']
-            item['field_name'] = item['name']
+            item['usage_count'] = item.get('count')
+            item['field_name'] = item.get('name')
 
-            item['message'] = f'{item["field_name"]}: {item["value"]} (times used: {item["usage_count"]})'
+            item['message'] = f'{item["field_name"]}: {item.get("value")} '                               f'(times used: {item["usage_count"]})'
 
-            del(item['name'], item['row_type'], item['count'], item['date_created'])
+            for key in ('name', 'row_type', 'count', 'date_created'):
+                item.pop(key, None)
             return item
 
         if isinstance(obj, Chrome.BookmarkItem):
@@ -369,11 +418,12 @@ class HindsightEncoder(json.JSONEncoder):
             item['timestamp_desc'] = 'Used Time'
             item['data_type'] = 'chrome:login_item:entry'
             item['source_long'] = 'Chrome Logins'
-            item['usage_count'] = item['count']
+            item['usage_count'] = item.get('count')
 
-            item['message'] = f'{item["name"]}: {item["value"]} used on {item["url"]} (total times used: {item["usage_count"]})'
+            item['message'] = f'{item.get("name")}: {item.get("value")} used on '                               f'{item.get("url")} (total times used: {item["usage_count"]})'
 
-            del (item['row_type'], item['count'], item['date_created'])
+            for key in ('row_type', 'count', 'date_created'):
+                item.pop(key, None)
             return item
 
         if isinstance(obj, Chrome.PreferenceItem):
@@ -439,6 +489,66 @@ class HindsightEncoder(json.JSONEncoder):
             del(item['row_type'], item['name'])
             return item
 
+        if isinstance(obj, WebBrowser.ServiceWorkerItem):
+            item = HindsightEncoder.base_encoder(obj)
+            item['source_long'] = 'Chrome Service Workers'
+            item['data_type'] = 'chrome:service_worker:registration'
+            HindsightEncoder.promote_timestamp(
+                item, 'last_modified', 'Registration Last Modified')
+            item['message'] = (f"{item.get('scope_url', '')} "
+                               f"(script: {item.get('script_url', '')})")
+            item.pop('row_type', None)
+            return item
+
+        if isinstance(obj, WebBrowser.ServiceWorkerResourceItem):
+            item = HindsightEncoder.base_encoder(obj)
+            item['source_long'] = 'Chrome Service Workers'
+            item['data_type'] = 'chrome:service_worker:resource'
+            item['timestamp_desc'] = 'Not a time'
+            # A purgeable resource is one the browser has orphaned from its
+            # registration, so the state is worth stating; and ~1% have no origin at
+            # all, which is why it is appended rather than embedded.
+            message = f"resource {item.get('resource_id', '')}"
+            if item.get('resource_state'):
+                message += f" ({item['resource_state']})"
+            if item.get('origin'):
+                message += f" for {item['origin']}"
+            item['message'] = message
+            item.pop('row_type', None)
+            return item
+
+        if isinstance(obj, WebBrowser.ServiceWorkerScriptItem):
+            item = HindsightEncoder.base_encoder(obj)
+            item['source_long'] = 'Chrome Service Workers'
+            item['data_type'] = 'chrome:service_worker:script'
+            HindsightEncoder.promote_timestamp(
+                item, 'response_time', 'Script Response Time')
+            item['message'] = (f"{item.get('url', '')} "
+                               f"({item.get('content_type', '')}, "
+                               f"{item.get('body_size', '')} bytes)")
+            item.pop('row_type', None)
+            return item
+
+        if isinstance(obj, WebBrowser.ServiceWorkerCacheStorageItem):
+            item = HindsightEncoder.base_encoder(obj)
+            item['source_long'] = 'Chrome Service Workers'
+            item['data_type'] = 'chrome:service_worker:cache_entry'
+            HindsightEncoder.promote_timestamp(item, 'entry_time', 'Cache Entry Time')
+            item['message'] = (f"{item.get('request_url', '')} "
+                               f"(cache: {item.get('cache_name', '')})")
+            item.pop('row_type', None)
+            return item
+
+        if isinstance(obj, WebBrowser.ServiceWorkerUserDataItem):
+            item = HindsightEncoder.base_encoder(obj)
+            item['source_long'] = 'Chrome Service Workers'
+            item['data_type'] = 'chrome:service_worker:user_data'
+            item['timestamp_desc'] = 'Not a time'
+            item['message'] = (f"{item.get('user_data_key', '')} "
+                               f"for {item.get('scope_url', '') or item.get('origin', '')}")
+            item.pop('row_type', None)
+            return item
+
         if isinstance(obj, WebBrowser.CacheItem):
             item = HindsightEncoder.base_encoder(obj)
 
@@ -465,6 +575,20 @@ class HindsightEncoder(json.JSONEncoder):
 
             del item['row_type']
             return item
+
+        # No branch matched. Emitting the record generically beats dropping it: a
+        # dropped record is absent from the output while the run still counts it, so the
+        # report is short by an amount nothing states. This is how Service Worker data
+        # and Firefox history went missing from JSONL for as long as they did.
+        item = HindsightEncoder.base_encoder(obj)
+        row_type = item.get('row_type') or type(obj).__name__
+        item['data_type'] = 'hindsight:' + re.sub(
+            r'[^a-z0-9]+', '_', str(row_type).lower()).strip('_')
+        item.setdefault('timestamp_desc', 'Not a time')
+        item.setdefault('message', str(item.get('value', '')))
+        item.pop('row_type', None)
+        HindsightEncoder.warn_unhandled(type(obj).__name__, item['data_type'])
+        return item
 
 
 class AnalysisSession(object):
@@ -3073,6 +3197,7 @@ class AnalysisSession(object):
                         (item.row_type, sql_date(friendly_date(item.timestamp)), item.url, item.name, item.value,
                          item.interpretation, item.profile, item.source_item))
 
+            unhandled_storage = collections.Counter()
             for item in self.parsed_storage:
                 if item.row_type.startswith('local'):
                     c.execute(
@@ -3102,6 +3227,17 @@ class AnalysisSession(object):
                          state_to_int(item.state), item.state,
                          item.file_exists, item.file_size, item.magic_results))
 
+                elif item.row_type.startswith('service worker'):
+                    c.execute(
+                        'INSERT INTO storage (type, origin, key, value, modification_time, '
+                        'interpretation, profile, source_path, seq, state, state_friendly) '
+                        'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                        (item.row_type, getattr(item, 'origin', None), item.key, item.value,
+                         sql_date(getattr(item, 'last_modified', None)),
+                         getattr(item, 'interpretation', None), item.profile,
+                         item.source_path, getattr(item, 'seq', None),
+                         state_to_int(item.state), item.state))
+
                 elif item.row_type.startswith('indexed'):
                     c.execute(
                         'INSERT INTO storage (type, origin, key, value, '
@@ -3109,6 +3245,15 @@ class AnalysisSession(object):
                         'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
                         (item.row_type, item.origin, item.key, item.value, item.interpretation, item.profile,
                          item.source_path, item.seq, state_to_int(item.state), item.state, item.database))
+
+                else:
+                    # Previously fell through with no branch and no message, which is
+                    # how every Service Worker row went missing from this table.
+                    unhandled_storage[item.row_type] += 1
+
+            for row_type, count in unhandled_storage.most_common():
+                log.error(f'{count} "{row_type}" record(s) are MISSING from the SQLite '
+                          f'storage table; no INSERT branch handles that row_type')
 
             for item in self.parsed_extension_data:
                 if item.row_type:
@@ -3242,7 +3387,7 @@ class AnalysisSession(object):
             if unparsed_count:
                 log.error(
                     f'{unparsed_count} record(s) could not be written to JSONL and are '
-                    f'MISSING from this output; HindsightEncoder has no branch for '
-                    f'their class:')
+                    f'MISSING from this output; HindsightEncoder returned nothing for '
+                    f'them, which it should no longer do for any class:')
                 for name, count in unparsed_types.most_common():
                     log.error(f'  - {count} x {name}')

--- a/tests/test_output_coverage.py
+++ b/tests/test_output_coverage.py
@@ -136,6 +136,59 @@ class TestServiceWorkerRecords(unittest.TestCase):
         self.assertFalse(encoded['message'].rstrip().endswith('for'))
 
 
+class TestEncoderToleratesMissingOptionalFields(unittest.TestCase):
+    """No branch may index a field the record might not have.
+
+    base_encoder drops keys whose value is None, so a record that didn't record an
+    optional field arrives without that key. Indexing it raises KeyError, and that
+    escapes write_jsonl_record and aborts the *whole* JSONL file -- every remaining
+    record lost, not the one that was odd. Realistic triggers: a visited page with a
+    NULL title, or Firefox formhistory on a schema with no timesUsed.
+    """
+
+    def _minimal(self, owner, name, row_type):
+        """A record carrying only what every record has -- nothing optional."""
+        cls = getattr(owner, name)
+        obj = cls.__new__(cls)
+        obj.__dict__.update(profile='p', row_type=row_type, timestamp=REF)
+        return obj
+
+    def _record_classes(self):
+        for owner in (WebBrowser, Chrome, Firefox):
+            for name in sorted(dir(owner)):
+                if not name.endswith(('Item', 'Setting', 'Extension')):
+                    continue
+                cls = getattr(owner, name)
+                if isinstance(cls, type):
+                    yield owner, name, cls
+
+    def test_no_branch_raises_on_a_record_with_only_required_fields(self):
+        failures = []
+        for owner, name, _cls in self._record_classes():
+            obj = self._minimal(owner, name, 'test')
+            try:
+                json.dumps(obj, cls=HindsightEncoder)
+            except Exception as exc:
+                failures.append(f'{owner.__name__}.{name}: '
+                                f'{type(exc).__name__}: {exc}')
+        self.assertEqual([], failures, '\n' + '\n'.join(failures))
+
+    def test_a_visited_page_with_no_title_still_encodes(self):
+        # The concrete case: Chrome/Firefox both record NULL titles.
+        item = Chrome.URLItem.__new__(Chrome.URLItem)
+        item.__dict__.update(profile='p', row_type='url', timestamp=REF,
+                             url='https://example.com', title=None, visit_count=1)
+        encoded = encode(item)
+        self.assertEqual('chrome:history:page_visited', encoded['data_type'])
+        self.assertIn('example.com', encoded['message'])
+
+    def test_a_cookie_with_no_host_still_encodes(self):
+        item = Chrome.CookieItem.__new__(Chrome.CookieItem)
+        item.__dict__.update(profile='p', row_type='cookie (created)', timestamp=REF)
+        encoded = encode(item)
+        self.assertEqual('chrome:cookie:entry', encoded['data_type'])
+
+
 class TestUnhandledRecordsAreStillWritten(unittest.TestCase):
     """An unknown class is written generically, not dropped.
 

--- a/tests/test_output_coverage.py
+++ b/tests/test_output_coverage.py
@@ -1,0 +1,161 @@
+import datetime
+import json
+import unittest
+
+from pyhindsight.analysis import HindsightEncoder
+from pyhindsight.browsers.chrome import Chrome
+from pyhindsight.browsers.firefox import Firefox
+from pyhindsight.browsers.webbrowser import WebBrowser
+
+UTC = datetime.timezone.utc
+REF = datetime.datetime(2024, 1, 15, 12, 0, tzinfo=UTC)
+
+
+def encode(item):
+    return json.loads(json.dumps(item, cls=HindsightEncoder))
+
+
+class TestNothingIsDroppedFromJsonl(unittest.TestCase):
+    """No parsed record may serialize to null.
+
+    A record the encoder returns None for is written as the literal `null` and then
+    skipped, so it is absent from the output while the run still counts it -- the report
+    is short by an amount nothing states. Service Worker data (five classes) and Firefox
+    history/downloads were lost that way, on every profile, for a long time.
+    """
+
+    # Classes that had no branch at all, plus the two Firefox ones that fell through
+    # because Chrome *defines* URLItem and DownloadItem while inheriting everything else.
+    PREVIOUSLY_DROPPED = [
+        (WebBrowser, 'ServiceWorkerItem', 'service worker (registration)'),
+        (WebBrowser, 'ServiceWorkerResourceItem', 'service worker (resource)'),
+        (WebBrowser, 'ServiceWorkerScriptItem', 'service worker (script body)'),
+        (WebBrowser, 'ServiceWorkerCacheStorageItem', 'service worker (cache storage)'),
+        (WebBrowser, 'ServiceWorkerUserDataItem', 'service worker (push subscription)'),
+        (Firefox, 'URLItem', 'url'),
+        (Firefox, 'DownloadItem', 'download'),
+    ]
+
+    def _bare(self, owner, name, row_type):
+        cls = getattr(owner, name)
+        obj = cls.__new__(cls)           # only the fields matter to the encoder
+        obj.__dict__.update(profile='p', row_type=row_type, key='k', value='v',
+                            state='Live', source_path='s')
+        return obj
+
+    def test_the_previously_dropped_classes_now_encode(self):
+        for owner, name, row_type in self.PREVIOUSLY_DROPPED:
+            with self.subTest(cls=f'{owner.__name__}.{name}'):
+                obj = self._bare(owner, name, row_type)
+                self.assertNotEqual('null', json.dumps(obj, cls=HindsightEncoder))
+
+    def test_each_of_them_has_a_branch_of_its_own(self):
+        # Not merely caught by the generic fallback -- their shape was chosen.
+        for owner, name, row_type in self.PREVIOUSLY_DROPPED:
+            with self.subTest(cls=f'{owner.__name__}.{name}'):
+                data_type = encode(self._bare(owner, name, row_type))['data_type']
+                self.assertFalse(
+                    data_type.startswith('hindsight:'),
+                    f'{name} is only handled by the generic fallback ({data_type})')
+
+class TestFirefoxHistoryAndDownloads(unittest.TestCase):
+    """Firefox URLItem and DownloadItem used to be dropped.
+
+    Chrome *defines* only URLItem and DownloadItem; every other `Chrome.X` in the
+    encoder chain resolves to the inherited `WebBrowser.X`, so Firefox's siblings
+    matched by accident everywhere else -- and were dropped for exactly these two.
+    """
+
+    def test_a_firefox_url_record_encodes(self):
+        item = Firefox.URLItem(
+            profile='p', visit_id=1, url='https://example.com', title='Example',
+            visit_time=REF, last_visit_time=REF, visit_count=2, typed_count=0,
+            from_visit=None, transition=1, hidden=False, favicon_id=None)
+        item.timestamp = REF
+        item.row_type = 'url'
+        encoded = encode(item)
+        self.assertEqual('chrome:history:page_visited', encoded['data_type'])
+        self.assertIn('example.com', encoded['message'])
+
+    def test_a_firefox_download_encodes_without_byte_counts(self):
+        # places.sqlite records no received/total bytes. base_encoder drops None, so a
+        # branch that indexed those keys unconditionally raised KeyError.
+        item = Firefox.DownloadItem(
+            profile='p', download_id=1, url='https://example.com/f.zip',
+            received_bytes=None, total_bytes=None, state=None,
+            full_path='C:/Users/t/Downloads/f.zip')
+        item.timestamp = REF
+        item.row_type = 'download'
+        encoded = encode(item)
+        self.assertEqual('chrome:history:file_downloaded', encoded['data_type'])
+        self.assertIn('f.zip', encoded['message'])
+        self.assertNotIn('bytes', encoded['message'])
+
+
+class TestServiceWorkerRecords(unittest.TestCase):
+    """All five Service Worker classes had no branch at all."""
+
+    def _item(self, cls_name, **fields):
+        cls = getattr(WebBrowser, cls_name)
+        obj = cls.__new__(cls)
+        obj.__dict__.update(profile='p', key='k', value='v', state='Live',
+                            source_path='s', **fields)
+        return obj
+
+    def test_registration_uses_its_own_timestamp(self):
+        # These carry their time in a field of their own, not in `timestamp`, so
+        # without promotion every one of them lands at the epoch.
+        encoded = encode(self._item(
+            'ServiceWorkerItem', row_type='service worker (registration)',
+            last_modified=REF, scope_url='https://example.com/', script_url='sw.js'))
+        self.assertEqual('chrome:service_worker:registration', encoded['data_type'])
+        self.assertEqual('Registration Last Modified', encoded['timestamp_desc'])
+        self.assertTrue(encoded['datetime'].startswith('2024-01-15'))
+
+    def test_cache_entry_uses_its_entry_time(self):
+        encoded = encode(self._item(
+            'ServiceWorkerCacheStorageItem', row_type='service worker (cache storage)',
+            entry_time=REF, request_url='https://example.com/a.js', cache_name='v1'))
+        self.assertEqual('chrome:service_worker:cache_entry', encoded['data_type'])
+        self.assertTrue(encoded['datetime'].startswith('2024-01-15'))
+
+    def test_a_record_with_no_time_is_labelled_as_timeless(self):
+        # Rather than asserting a 1970 event that never happened.
+        encoded = encode(self._item(
+            'ServiceWorkerResourceItem', row_type='service worker (resource)',
+            resource_id=288, resource_state='purgeable', origin=''))
+        self.assertEqual('Not a time', encoded['timestamp_desc'])
+
+    def test_a_resource_message_survives_a_missing_origin(self):
+        # ~1% of them are orphaned from any registration and carry no origin.
+        encoded = encode(self._item(
+            'ServiceWorkerResourceItem', row_type='service worker (resource)',
+            resource_id=288, resource_state='purgeable', origin=''))
+        self.assertIn('288', encoded['message'])
+        self.assertIn('purgeable', encoded['message'])
+        self.assertFalse(encoded['message'].rstrip().endswith('for'))
+
+
+class TestUnhandledRecordsAreStillWritten(unittest.TestCase):
+    """An unknown class is written generically, not dropped.
+
+    Dropping is what made the original bug invisible: the run counted the records and
+    the output simply didn't contain them.
+    """
+
+    def test_an_unknown_class_still_produces_a_record(self):
+        class Invented:
+            def __init__(self):
+                self.profile = 'p'
+                self.row_type = 'brand new artifact'
+                self.key = 'k'
+                self.value = 'v'
+                self.timestamp = REF
+
+        encoded = encode(Invented())
+        self.assertEqual('hindsight:brand_new_artifact', encoded['data_type'])
+        self.assertIn('datetime', encoded)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Service Worker data and Firefox history/downloads parsed and counted correctly, and then
never reached some output formats. Everything was right except the writing.

| artifact | XLSX | JSONL | SQLite |
|---|---|---|---|
| Service Worker (5 classes, 4,184 records) | 4,213 rows | **0** | **0** |
| Firefox history + downloads | present | **0** | present |

## Why it happened

Two dispatchers, one failure mode: neither had a final `else`, so an unrecognised record
fell through in silence.

**`HindsightEncoder.default()`** matches on `isinstance(obj, Chrome.X)`. Chrome *defines*
only `URLItem` and `DownloadItem` — every other `Chrome.X` in that chain resolves to the
inherited `WebBrowser.X`, so Firefox's siblings matched by accident everywhere else and
were dropped for exactly those two. The five `ServiceWorker*Item` classes had no branch at
all. No match returned `None`, `json.dumps` produced `'null'`, and the writer skipped it.

**`generate_sqlite()`** matches on `item.row_type.startswith(...)` with branches for
`local` / `session` / `file system` / `indexed` and no `else`, so every
`service worker ...` row was discarded.

## What changed

Firefox history and downloads now match on the `WebBrowser` base class, which is what the
rest of the chain was already doing. The five Service Worker classes get branches of their
own — they carry their time in a field of their own rather than in `timestamp`, so each
promotes the right one (`last_modified`, `entry_time`, `response_time`) into `datetime`
instead of taking the epoch placeholder; ones with no real time are labelled `Not a time`
rather than asserting a 1970 event. SQLite gains a service worker branch.

Both dispatchers now have a final `else`. JSONL writes an unrecognised class generically
and warns once naming it; SQLite logs any `row_type` no branch handles. A record can no
longer disappear between being counted and being written.

## The worse bug found alongside it

`base_encoder` drops keys whose value is `None`, so a record missing an optional field
arrives without that key — and several branches indexed those keys directly. The
resulting `KeyError` escapes `write_jsonl_record`, which has no handler, so it propagates
out of `generate_jsonl` and **abandons the file**. Every record after the odd one is lost,
not the odd one, and the only symptom is a traceback that doesn't say which artifact
caused it.

Both triggers are ordinary: a visited page the browser recorded with no title
(`item['title']`), or Firefox `formhistory` on a schema without `timesUsed`
(`item['count']`).

Swept the whole encoder: 17 `del item[...]` became `item.pop(..., None)`, and 46 reads of
keys the branch doesn't itself set earlier became `item.get(...)`. Two needed `or ''`
rather than `.get()`, because `.get()` prevents the `KeyError` but not `None` flowing on:

```python
item['url'] = item.get('origin')[1:]        # TypeError: not subscriptable
item['url'] = item.get('url').lstrip('.')   # AttributeError
```

## Result

No existing `data_type` count changed on any profile — these are pure additions, and the
hardening changes no output at all.

| profile | before | after | recovered |
|---|---|---|---|
| Bob (Chrome) | 2,786 | 6,970 | **+4,184** — exactly what the run had been reporting |
| Firefox fixture | 68 | 72 | **+4** |
| Ryan_v147 | 67,346 | 86,939 | **+19,593** |

All three formats write cleanly with no warnings about dropped records. 174 tests pass.

`tests/test_output_coverage.py` pins both halves: that the previously-dropped classes
encode and each has a branch of its own rather than falling through to the generic one,
and that no branch raises when fed a record carrying only `profile`, `row_type` and
`timestamp`. That last test is what found the two `or ''` cases — each looks reasonable on
its own line, which is why they're easy to miss by reading.
