### PR TITLE
Add GitHub Actions workflow for matrix-based Python unit tests and up…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,10 @@
 #   separators, line endings, file locking) does not vary by Python minor version.
 # - Widening this is a one-line change: add entries to the include list.
 #
-# 3.10 is the floor, set by ccl_chromium_reader (requires-python >=3.10) and
-# declared to match in setup.py.
+# 3.11 is the floor, declared to match in setup.py. ccl_chromium_reader allows
+# 3.10, but pyhindsight.utils uses datetime.UTC, which does not exist before
+# 3.11. 3.10 reaches end of life in October 2026, so the floor moved rather
+# than the code.
 name: Tests
 
 on:
@@ -41,8 +43,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.10'
-          - os: ubuntu-latest
             python: '3.11'
           - os: ubuntu-latest
             python: '3.12'
@@ -51,7 +51,7 @@ jobs:
           - os: ubuntu-latest
             python: '3.14'
           - os: windows-latest
-            python: '3.10'
+            python: '3.11'
           - os: windows-latest
             python: '3.14'
           - os: macos-15 # pinned rather than -latest so the environment does not

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,80 @@
+# Runs the unit test suite on every push and pull request.
+#
+# The suite is fast (about 4 seconds for 185 tests) and self-contained: no network,
+# no platform guards, and every fixture is committed under tests/fixtures. The job
+# cost is almost entirely runner startup and dependency install, so the matrix is
+# sized for coverage rather than for minutes.
+#
+# Matrix shape:
+# - Linux carries the full supported Python range. Version-specific breakage in this
+#   codebase is OS-independent (it is pure Python; the platform-specific pieces are
+#   pywin32 and path handling), so running every minor version on all three operating
+#   systems mostly re-tests the same thing.
+# - Windows and macOS run the floor and the ceiling. OS-specific breakage (path
+#   separators, line endings, file locking) does not vary by Python minor version.
+# - Widening this is a one-line change: add entries to the include list.
+#
+# 3.10 is the floor, set by ccl_chromium_reader (requires-python >=3.10) and
+# declared to match in setup.py.
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# A newer push to the same branch makes an in-flight run redundant.
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: ${{ matrix.os }} / Python ${{ matrix.python }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false # one platform failing should not hide the others
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python: '3.10'
+          - os: ubuntu-latest
+            python: '3.11'
+          - os: ubuntu-latest
+            python: '3.12'
+          - os: ubuntu-latest
+            python: '3.13'
+          - os: ubuntu-latest
+            python: '3.14'
+          - os: windows-latest
+            python: '3.10'
+          - os: windows-latest
+            python: '3.14'
+          - os: macos-15 # pinned rather than -latest so the environment does not
+                         # silently migrate underneath the suite
+            python: '3.11' # macOS floor; arm64 coverage for 3.10 is not dependable
+          - os: macos-15
+            python: '3.14'
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-test.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt -r requirements-test.txt
+
+      # Several tests build fixture paths relative to the working directory
+      # (os.path.join('tests', 'fixtures', ...)), so this has to run from the
+      # repo root rather than from tests/.
+      - name: Run tests
+        run: pytest tests/ -v

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,12 @@
+# Test-only dependencies. Install alongside requirements.txt to run the suite:
+#   pip install -r requirements.txt -r requirements-test.txt
+#   pytest tests/
+#
+# Kept separate from requirements-dev.txt so CI does not pull grpcio-tools, which
+# is only needed to regenerate the protobuf modules and is slow to install.
+#
+# openpyxl is not a runtime dependency. Hindsight writes XLSX with xlsxwriter,
+# which cannot read a workbook back; test_xlsx_none_safety.py reads the file it
+# just wrote to check that a None in one column did not drop the rest of the row.
+openpyxl>=3.1
+pytest>=8

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from pyhindsight import __pypi_version__
 setup(
   name='pyhindsight',
-  python_requires='>=3.10',
+  python_requires='>=3.11',
   packages=find_packages(),
   include_package_data=True,
   scripts=['hindsight.py', 'hindsight_gui.py'],

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from pyhindsight import __pypi_version__
 setup(
   name='pyhindsight',
-  python_requires='>=3.9',
+  python_requires='>=3.10',
   packages=find_packages(),
   include_package_data=True,
   scripts=['hindsight.py', 'hindsight_gui.py'],


### PR DESCRIPTION
…date minimum Python version to 3.10 in `setup.py`.