### PR TITLE
Add encoding resilience to progress display and stdout

### DIFF
--- a/hindsight.py
+++ b/hindsight.py
@@ -21,7 +21,7 @@ import pyhindsight
 import pyhindsight.plugins
 from pyhindsight.analysis import AnalysisSession
 from pyhindsight.artifact_filter import ArtifactFilter, UnknownArtifactError, format_catalog
-from pyhindsight.utils import get_rich_banner
+from pyhindsight.utils import get_rich_banner, make_stdout_resilient
 
 import rich.align
 import rich.console
@@ -156,6 +156,8 @@ The Chrome Profile folder default locations are:
 
 def main():
 
+    make_stdout_resilient()
+
     def write_excel(analysis_session):
         import io
 
@@ -225,10 +227,12 @@ def main():
     analysis_session.temp_dir = args.temp_dir
     analysis_session.log_path = args.log
 
-    # Set up logging
+    # Set up logging. encoding is explicit because the default is the platform's, cp1252
+    # on Windows, which silently mangles anything outside it. logging swallows handler
+    # errors, so this never raised; it just lost characters from the record of the run.
     logging.basicConfig(filename=analysis_session.log_path, level=logging.DEBUG,
                         format='%(asctime)s.%(msecs).03d | %(levelname).01s | %(message)s',
-                        datefmt='%Y-%m-%d %H:%M:%S')
+                        datefmt='%Y-%m-%d %H:%M:%S', encoding='utf-8')
     log = logging.getLogger(__name__)
 
     # Hindsight version info

--- a/hindsight_gui.py
+++ b/hindsight_gui.py
@@ -9,7 +9,7 @@ import importlib
 import pyhindsight
 import pyhindsight.plugins
 from pyhindsight.analysis import AnalysisSession
-from pyhindsight.utils import get_rich_banner
+from pyhindsight.utils import get_rich_banner, make_stdout_resilient
 import rich.align
 import rich.console
 
@@ -297,6 +297,7 @@ def sqlite_view():
 
 
 def main():
+    make_stdout_resilient()
     console = rich.console.Console()
     console.print(rich.align.Align.center(get_rich_banner()))
     global STATIC_PATH

--- a/pyhindsight/analysis.py
+++ b/pyhindsight/analysis.py
@@ -18,7 +18,8 @@ from pyhindsight.artifact_filter import ArtifactFilter
 from pyhindsight.browsers.chrome import Chrome
 from pyhindsight.browsers.firefox import Firefox
 from pyhindsight.browsers.webbrowser import (
-    ARTIFACT_STATUS_FAILED, ARTIFACT_STATUS_SKIPPED, WebBrowser, timeline_sort_key)
+    ARTIFACT_STATUS_FAILED, ARTIFACT_STATUS_SKIPPED, WebBrowser, spinner_name,
+    timeline_sort_key)
 from pyhindsight.utils import friendly_date
 import pyhindsight.plugins
 import rich.align
@@ -1385,7 +1386,7 @@ class AnalysisSession(object):
             return text
 
         def running_status():
-            return rich.spinner.Spinner("dots")
+            return rich.spinner.Spinner(spinner_name(console))
 
         def build_plugin_table():
             table = rich.table.Table(show_header=False, box=None, expand=False)

--- a/pyhindsight/browsers/webbrowser.py
+++ b/pyhindsight/browsers/webbrowser.py
@@ -29,6 +29,17 @@ ARTIFACT_STATUS_PARTIAL = 'partial'
 # Marks a row whose parser is still running, so the table renders a spinner for it.
 _SPINNER = object()
 
+
+def spinner_name(console):
+    """Return a spinner whose frames the console's encoding can represent.
+
+    rich swaps its box characters for ASCII when the encoding cannot carry them
+    (`ConsoleOptions.ascii_only`) but does not do the same for `Spinner`, whose default
+    "dots" frames are Braille. On a cp1252 stream those frames are what raises.
+    """
+    return 'line' if console.options.ascii_only else 'dots'
+
+
 # Every collection a parser can deliver results into. The driver snapshots their sizes
 # around each parser so it can catch the one failure a count cannot reveal on its own:
 # results parsed and counted, then dropped before they reach any of these.
@@ -442,7 +453,8 @@ class ProcessingDisplay:
         leading = " " * (self.count_width - 1)
         spinner = rich.columns.Columns(
             [rich.text.Text("  [ ", style="dim"), rich.text.Text(leading),
-             rich.spinner.Spinner("dots", text="", style="green"), rich.text.Text(" ]  ", style="dim")],
+             rich.spinner.Spinner(spinner_name(self.console), text="", style="green"),
+             rich.text.Text(" ]  ", style="dim")],
             expand=False,
             equal=False,
             padding=(0, 0))

--- a/pyhindsight/utils.py
+++ b/pyhindsight/utils.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import sqlite3
 import struct
+import sys
 from pyhindsight import __version__
 from pathlib import Path
 
@@ -436,6 +437,23 @@ def _supports_unicode():
         return True
     except (UnicodeEncodeError, LookupError):
         return False
+
+
+def make_stdout_resilient():
+    """Degrade unencodable characters on stdout instead of raising.
+
+    A redirected stdout on Windows is cp1252, and the progress display renders from
+    inside whatever parser is running, so a write that raises there is caught by that
+    parser's `except` and reported as an unreadable artifact. That silently cost 954
+    Session Storage records. Returns whether the stream was adjusted.
+    """
+    if not hasattr(sys.stdout, 'reconfigure'):
+        return False
+    try:
+        sys.stdout.reconfigure(errors='backslashreplace')
+    except (AttributeError, ValueError, OSError):
+        return False
+    return True
 
 
 def get_rich_banner():

--- a/tests/test_console_encoding.py
+++ b/tests/test_console_encoding.py
@@ -180,10 +180,16 @@ class TestStdoutIsResilient(unittest.TestCase):
                  '-o', os.path.join(tmp, 'out'), '-f', 'jsonl',
                  '-l', os.path.join(tmp, 'hindsight.log'),
                  '--temp_dir', os.path.join(tmp, 'temp')],
-                cwd=REPO_ROOT, capture_output=True, text=True, timeout=300, env=env)
+                # Decode as what the child was told to write. `text=True` would use the
+                # parent's locale, which matches only on a Windows runner.
+                cwd=REPO_ROOT, capture_output=True, encoding='cp1252', timeout=300,
+                env=env)
             self.assertEqual(0, result.returncode,
                              f'stdout:\n{result.stdout}\nstderr:\n{result.stderr}')
             self.assertNotIn('UnicodeEncodeError', result.stdout + result.stderr)
+            # The banner falls back to a bullet when the encoding cannot take its
+            # triangle, so its presence confirms the child really ran on cp1252.
+            self.assertIn('•', result.stdout)
             self.assertTrue(os.path.exists(os.path.join(tmp, 'out.jsonl')))
 
 

--- a/tests/test_console_encoding.py
+++ b/tests/test_console_encoding.py
@@ -1,0 +1,191 @@
+"""The progress display must never cost us records.
+
+On a cp1252 stdout, rich's Braille spinner raises when it renders, and because it renders
+from inside a running parser, that parser's `except` reports its artifact as unreadable.
+Three of nine test profiles lost their Session Storage this way, 954 records.
+
+Two defences: an encodable spinner (`spinner_name`), and stdout degrading unencodable
+characters (`utils.make_stdout_resilient`), which is the only one that covers writes
+from inside third-party code.
+"""
+
+import io
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import rich.console
+
+from pyhindsight.browsers.webbrowser import (
+    ProcessingDisplay,
+    WebBrowser,
+    spinner_name,
+)
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CHROME_FIXTURE = os.path.join('tests', 'fixtures', 'profiles', '60')
+
+# One frame of rich's "dots" spinner. Outside cp1252, which is the whole problem.
+BRAILLE = '\u280b'
+
+
+def cp1252_console(**kwargs):
+    """A console writing to a strict cp1252 stream, as a redirected run on Windows does."""
+    stream = io.TextIOWrapper(io.BytesIO(), encoding='cp1252', errors='strict')
+    return rich.console.Console(file=stream, width=110, **kwargs)
+
+
+class TestSpinnerRespectsTheStreamEncoding(unittest.TestCase):
+
+    def test_a_stream_that_cannot_carry_braille_gets_an_ascii_spinner(self):
+        self.assertEqual('line', spinner_name(cp1252_console()))
+
+    def test_a_utf8_stream_keeps_the_braille_spinner(self):
+        stream = io.TextIOWrapper(io.BytesIO(), encoding='utf-8')
+        self.assertEqual('dots', spinner_name(rich.console.Console(file=stream, width=110)))
+
+    def test_the_chosen_spinner_is_always_encodable(self):
+        # The property that actually matters, independent of which spinner is picked.
+        from rich._spinners import SPINNERS
+        console = cp1252_console()
+        for frame in SPINNERS[spinner_name(console)]['frames']:
+            frame.encode(console.encoding)
+
+
+class TestTheDisplaySurvivesACp1252Stream(unittest.TestCase):
+    """Rendering a running parser's row must not raise on a cp1252 stream.
+
+    Before the fix the spinner row rendered Braille and the write raised inside
+    `driver.run()`, taking the parser's count with it.
+    """
+
+    def _driver(self):
+        browser = WebBrowser('fixture-profile', 'Chrome')
+        browser.display_version = '999'
+        driver = ProcessingDisplay(browser, ['Group'])
+        driver.console = cp1252_console()
+        return driver
+
+    def test_the_live_view_renders_without_raising(self):
+        driver = self._driver()
+        with driver:
+            driver.group('Group')
+            # Put a spinner row on the table, then force the render that used to raise.
+            driver.output_groups.setdefault('Group', []).append(
+                ('Session Storage records', _spinner_marker(), None))
+            driver.console.print(driver._build_live_view())
+
+
+def _spinner_marker():
+    from pyhindsight.browsers import webbrowser
+    return webbrowser._SPINNER
+
+
+class TestTheFullChainOnACp1252Stdout(unittest.TestCase):
+    """The production path, end to end, out of process.
+
+    `ccl_chromium_sessionstorage` reports undecodable records with a bare `print()`, and
+    rich proxies stdout while the display is up, so that print renders into the cp1252
+    stream from inside the parser. Out of process because the guard mutates the real
+    `sys.stdout`, which pytest replaces.
+    """
+
+    SCRIPT = (
+        'import sys, io, json\n'
+        'sys.stdout = io.TextIOWrapper(open(sys.argv[1], "wb"), '
+        'encoding="cp1252", errors="strict")\n'
+        'from pyhindsight.utils import make_stdout_resilient\n'
+        'if sys.argv[2] == "guard":\n'
+        '    make_stdout_resilient()\n'
+        'from pyhindsight.browsers.webbrowser import ProcessingDisplay, WebBrowser\n'
+        'browser = WebBrowser("fixture-profile", "Chrome")\n'
+        'browser.display_version = "999"\n'
+        'driver = ProcessingDisplay(browser, ["Group"])\n'
+        'def parser():\n'
+        '    print("Invalid namespace key: \\u280b")  # what the ccl reader does\n'
+        '    return 678\n'
+        'with driver:\n'
+        '    driver.group("Group")\n'
+        '    driver.run("Session Storage", "Session Storage", parser,\n'
+        '               display_value="Session Storage records",\n'
+        '               artifact="session-storage")\n'
+        'sys.stdout.flush()\n'
+        'sys.stderr.write(json.dumps(browser.artifacts_counts.get("Session Storage")))\n'
+    )
+
+    def _run(self, mode):
+        with tempfile.TemporaryDirectory() as tmp:
+            return subprocess.run(
+                [sys.executable, '-c', self.SCRIPT, os.path.join(tmp, 'out.txt'), mode],
+                cwd=REPO_ROOT, capture_output=True, text=True, timeout=120)
+
+    def test_the_parsers_records_survive_a_librarys_stray_print(self):
+        result = self._run('guard')
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual('678', result.stderr.strip().splitlines()[-1])
+
+    def test_without_the_guard_the_same_run_loses_the_artifact(self):
+        # Pins the bug itself, so the fix cannot be quietly removed. Without the guard
+        # the write raises inside the parser and the count never reaches the browser.
+        result = self._run('no-guard')
+        survived = (result.returncode == 0
+                    and result.stderr.strip().endswith('678'))
+        self.assertFalse(
+            survived,
+            'A stray unencodable print no longer breaks the parse even without the '
+            'stdout guard. If rich or the parser changed, re-check whether '
+            'make_stdout_resilient() is still load-bearing before deleting this test.')
+
+
+class TestStdoutIsResilient(unittest.TestCase):
+
+    def test_the_guard_makes_an_unencodable_write_survivable(self):
+        # Run it out of process: the guard mutates the real sys.stdout, and pytest
+        # replaces stdout with an object that has no reconfigure().
+        script = (
+            'import sys, io\n'
+            'sys.stdout = io.TextIOWrapper(open(sys.argv[1], "wb"), '
+            'encoding="cp1252", errors="strict")\n'
+            'from pyhindsight.utils import make_stdout_resilient\n'
+            'make_stdout_resilient()\n'
+            'sys.stdout.write("\\u280b")\n'
+            'sys.stdout.flush()\n'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, 'out.txt')
+            result = subprocess.run([sys.executable, '-c', script, out],
+                                    cwd=REPO_ROOT, capture_output=True, text=True,
+                                    timeout=120)
+            self.assertEqual(0, result.returncode, result.stderr)
+            with open(out, 'rb') as f:
+                # backslashreplace, so the character is described rather than dropped.
+                self.assertEqual(rb'\u280b', f.read())
+
+    def test_the_guard_reports_failure_instead_of_raising(self):
+        from pyhindsight import utils
+        original = sys.stdout
+        try:
+            sys.stdout = object()  # no reconfigure, as under pytest capture
+            self.assertFalse(utils.make_stdout_resilient())
+        finally:
+            sys.stdout = original
+
+    def test_a_cli_run_completes_on_a_cp1252_stdout(self):
+        env = dict(os.environ, PYTHONIOENCODING='cp1252')
+        with tempfile.TemporaryDirectory() as tmp:
+            result = subprocess.run(
+                [sys.executable, 'hindsight.py', '-i', CHROME_FIXTURE,
+                 '-o', os.path.join(tmp, 'out'), '-f', 'jsonl',
+                 '-l', os.path.join(tmp, 'hindsight.log'),
+                 '--temp_dir', os.path.join(tmp, 'temp')],
+                cwd=REPO_ROOT, capture_output=True, text=True, timeout=300, env=env)
+            self.assertEqual(0, result.returncode,
+                             f'stdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+            self.assertNotIn('UnicodeEncodeError', result.stdout + result.stderr)
+            self.assertTrue(os.path.exists(os.path.join(tmp, 'out.jsonl')))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Enhancements:
- Introduced `make_stdout_resilient()` to prevent unencodable characters from breaking processing during stdout writes, especially on `cp1252` streams.
- Updated spinners to dynamically adjust based on console encoding (`spinner_name()`), ensuring compatibility with encodings like `cp1252`.
- Adjusted logging configuration to explicitly use `utf-8` encoding to avoid data loss on non-`utf-8` platforms.

Tests:
- Implemented comprehensive unit tests to validate encoding resilience, spinner compatibility, and end-to-end workflows under various stdout conditions.