### PR TITLE
Add end-to-end corpus parse tests

### DIFF
--- a/.github/workflows/corpus-tests.yml
+++ b/.github/workflows/corpus-tests.yml
@@ -1,0 +1,101 @@
+# End-to-end parses of real browser profiles, compared to committed baselines.
+#
+# Deliberately not on the pull-request path. The unit suite in tests.yml is the gate on
+# every push; this is a regression net that needs several GB of profile data and minutes
+# rather than seconds, so it runs nightly and on demand.
+#
+# Sharded one job per corpus root. That keeps each runner's disk to a single archive
+# rather than the whole 6 GB corpus, turns a failure into "magnet.ctf_2019 changed"
+# instead of one opaque red tick, and lets the roots run in parallel.
+#
+# The corpus lives as release assets on a public repo, one .tar.gz per root, so no token
+# and no secret are involved and a pull request from a fork gets the same coverage as a
+# branch here. That is the whole reason for publishing it rather than gating it behind a
+# repository secret.
+name: Corpus tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Nightly, well clear of the working day in US Pacific.
+    - cron: '0 11 * * *'
+
+concurrency:
+  group: corpus-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # Bump the tag when the corpus changes; the cache key below follows it, so a new tag
+  # re-downloads rather than silently reusing the previous corpus.
+  CORPUS_REPO: RyanDFIR/data-sets
+  CORPUS_TAG: corpus-v1
+
+jobs:
+  # The set of baseline files is the manifest. Deriving the matrix from it means adding a
+  # root is one generated baseline, with no second list here to forget to update.
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      roots: ${{ steps.roots.outputs.roots }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: roots
+        run: |
+          roots=$(python3 -c 'import json,pathlib;print(json.dumps(sorted(p.stem for p in pathlib.Path("tests/corpus/baselines").glob("*.json"))))')
+          echo "roots=$roots" >> "$GITHUB_OUTPUT"
+          echo "Corpus roots: $roots"
+
+  corpus:
+    needs: discover
+    name: ${{ matrix.root }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # one root changing should not hide the others
+      matrix:
+        root: ${{ fromJSON(needs.discover.outputs.roots) }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt --group test
+
+      # Restoring the extracted tree costs a fraction of re-downloading and re-extracting
+      # it. Keyed on the release tag, so bumping CORPUS_TAG invalidates it.
+      - name: Restore corpus root
+        id: corpus-cache
+        uses: actions/cache@v4
+        with:
+          path: corpus/${{ matrix.root }}
+          key: corpus-${{ env.CORPUS_TAG }}-${{ matrix.root }}
+
+      - name: Download and extract corpus root
+        if: steps.corpus-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p corpus
+          url="https://github.com/${CORPUS_REPO}/releases/download/${CORPUS_TAG}/${{ matrix.root }}.tar.gz"
+          echo "Fetching $url"
+          # --fail so a 404 stops the job here, with the URL in the log, rather than
+          # leaving tar to fail on an HTML error page.
+          curl --fail --location --silent --show-error --output root.tar.gz "$url"
+          tar -xzf root.tar.gz -C corpus
+          rm root.tar.gz
+          du -sh "corpus/${{ matrix.root }}"
+
+      - name: Run end-to-end parse
+        env:
+          HINDSIGHT_TEST_CORPUS: corpus
+          HINDSIGHT_TEST_CORPUS_ROOTS: ${{ matrix.root }}
+        run: pytest tests/test_corpus_e2e.py -v

--- a/.github/workflows/corpus-tests.yml
+++ b/.github/workflows/corpus-tests.yml
@@ -1,12 +1,18 @@
 # End-to-end parses of real browser profiles, compared to committed baselines.
 #
-# Deliberately not on the pull-request path. The unit suite in tests.yml is the gate on
-# every push; this is a regression net that needs several GB of profile data and minutes
-# rather than seconds, so it runs nightly and on demand.
+# Runs on every pull request, because a regression arrives with a commit and that is when
+# it is cheapest to find. A nightly schedule would only tell you something broke in the
+# last day and leave you to bisect for it, so there isn't one. Also on push to main, which
+# is not redundant with the pull-request run: merging a PR that was behind main produces a
+# commit no run has ever seen.
 #
 # Sharded one job per corpus root. That keeps each runner's disk to a single archive
 # rather than the whole 6 GB corpus, turns a failure into "magnet.ctf_2019 changed"
 # instead of one opaque red tick, and lets the roots run in parallel.
+#
+# No paths filter. Skipping doc-only pull requests would save bandwidth, but a filter that
+# is missing one file silently stops testing a real change, and a false green here is much
+# more expensive than a few gigabytes of transfer.
 #
 # The corpus lives as release assets on a public repo, one .tar.gz per root, so no token
 # and no secret are involved and a pull request from a fork gets the same coverage as a
@@ -15,10 +21,10 @@
 name: Corpus tests
 
 on:
+  pull_request:
+  push:
+    branches: [main]
   workflow_dispatch:
-  schedule:
-    # Nightly, well clear of the working day in US Pacific.
-    - cron: '0 11 * * *'
 
 concurrency:
   group: corpus-${{ github.workflow }}-${{ github.ref }}
@@ -28,8 +34,9 @@ permissions:
   contents: read
 
 env:
-  # Bump the tag when the corpus changes; the cache key below follows it, so a new tag
-  # re-downloads rather than silently reusing the previous corpus.
+  # Bump the tag when the corpus changes. A baseline and the corpus it was generated from
+  # have to move together: adding a baseline for a root that is not in this release fails
+  # the shard on the download, which is the right way round.
   CORPUS_REPO: RyanDFIR/data-sets
   CORPUS_TAG: corpus-v1
 
@@ -74,15 +81,12 @@ jobs:
 
       # Restoring the extracted tree costs a fraction of re-downloading and re-extracting
       # it. Keyed on the release tag, so bumping CORPUS_TAG invalidates it.
-      - name: Restore corpus root
-        id: corpus-cache
-        uses: actions/cache@v4
-        with:
-          path: corpus/${{ matrix.root }}
-          key: corpus-${{ env.CORPUS_TAG }}-${{ matrix.root }}
-
+      # Downloaded every run rather than cached. The extracted corpus is 5.9 GB across the
+      # six roots, and a repository only gets 10 GB of Actions cache with LRU eviction, so
+      # caching it would crowd out the pip caches the other workflows depend on and then
+      # get evicted itself. A release asset pulled from GitHub to a GitHub runner is fast
+      # enough that the cache was buying very little for that price.
       - name: Download and extract corpus root
-        if: steps.corpus-cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p corpus
           url="https://github.com/${CORPUS_REPO}/releases/download/${CORPUS_TAG}/${{ matrix.root }}.tar.gz"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@
 #   separators, line endings, file locking) does not vary by Python minor version.
 # - Widening this is a one-line change: add entries to the include list.
 #
-# 3.11 is the floor, declared to match in setup.py. ccl_chromium_reader allows
+# 3.11 is the floor, declared to match in pyproject.toml. ccl_chromium_reader allows
 # 3.10, but pyhindsight.utils uses datetime.UTC, which does not exist before
 # 3.11. 3.10 reaches end of life in October 2026, so the floor moved rather
 # than the code.

--- a/tests/corpus/baselines/bf4sa_2025_bob-1.json
+++ b/tests/corpus/baselines/bf4sa_2025_bob-1.json
@@ -1,0 +1,402 @@
+{
+  "data_types": {
+    "chrome:autofill:entry": 12,
+    "chrome:bookmark:entry": 2,
+    "chrome:cache:entry": 8227,
+    "chrome:cookie:entry": 4738,
+    "chrome:extension:installed": 14,
+    "chrome:extension_storage:entry": 2967,
+    "chrome:file_system:entry": 2,
+    "chrome:history:file_downloaded": 27,
+    "chrome:history:page_visited": 695,
+    "chrome:indexeddb:entry": 35235,
+    "chrome:local_storage:entry": 4066,
+    "chrome:login_item:entry": 8,
+    "chrome:preferences:entry": 121,
+    "chrome:service_worker:cache_entry": 1830,
+    "chrome:service_worker:registration": 301,
+    "chrome:service_worker:resource": 748,
+    "chrome:service_worker:script": 34,
+    "chrome:service_worker:user_data": 2,
+    "chrome:session:closed_tab": 51,
+    "chrome:session:closed_window": 9,
+    "chrome:session:navigation": 450,
+    "chrome:session:tab_closed": 2,
+    "chrome:session:tab_last_active": 30,
+    "chrome:session_storage:entry": 827,
+    "chrome:site_setting:entry": 653,
+    "chrome:sync_data:entry": 3673
+  },
+  "generated_by": {
+    "generated_utc": "2026-09-04T17:01:08Z",
+    "hindsight_version": "2026.06"
+  },
+  "profiles": {
+    "Default": {
+      "artifacts": {
+        "Autofill": {
+          "count": 8,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Bookmarks": {
+          "count": 2,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cache": {
+          "count": 6397,
+          "status": "partial",
+          "unparsed_records": 601,
+          "unparsed_sources": 0
+        },
+        "Cookies": {
+          "count": 4601,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "DIPS": {
+          "count": 74,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "DIPS Popups": {
+          "count": 5,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "DawnGraphiteCache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "DawnWebGPUCache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Rules": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Scripts": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension State": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extensions": {
+          "count": 2,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "File System": {
+          "count": 2,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "GPUCache": {
+          "count": 0,
+          "status": "partial",
+          "unparsed_records": 9,
+          "unparsed_sources": 0
+        },
+        "HSTS": {
+          "count": 308,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History": {
+          "count": 451,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History_downloads": {
+          "count": 5,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "IndexedDB": {
+          "count": 7460,
+          "status": "partial",
+          "unparsed_records": 0,
+          "unparsed_sources": 2
+        },
+        "Local Extension Settings": {
+          "count": 1,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Local Storage": {
+          "count": 3993,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Login Data": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Managed Extension Settings": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Platform Notifications": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Preferences": {
+          "count": 211,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Secure Preferences": {
+          "count": 7,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Service Workers": {
+          "count": 2376,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Session Storage": {
+          "count": 820,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sessions": {
+          "count": 509,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Site Characteristics": {
+          "count": 66,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sync Data": {
+          "count": 2910,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "shared_proto_db downloads": {
+          "count": 22,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        }
+      },
+      "browser": "Chrome"
+    },
+    "Profile 1": {
+      "artifacts": {
+        "Autofill": {
+          "count": 4,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Bookmarks": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cookies": {
+          "count": 137,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "DIPS": {
+          "count": 6,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "DIPS Popups": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "DawnGraphiteCache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "DawnWebGPUCache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Rules": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Scripts": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension State": {
+          "count": 2924,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extensions": {
+          "count": 3,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "GPUCache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "HSTS": {
+          "count": 29,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History": {
+          "count": 244,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History_downloads": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "IndexedDB": {
+          "count": 27775,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Local Extension Settings": {
+          "count": 42,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Local Storage": {
+          "count": 73,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Login Data": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Preferences": {
+          "count": 68,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Secure Preferences": {
+          "count": 7,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Service Workers": {
+          "count": 539,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Session Storage": {
+          "count": 7,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sessions": {
+          "count": 33,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Site Characteristics": {
+          "count": 2,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sync Data": {
+          "count": 763,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "shared_proto_db downloads": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        }
+      },
+      "browser": "Chrome"
+    }
+  },
+  "root": "bf4sa_2025_bob-1",
+  "total_records": 64724
+}

--- a/tests/corpus/baselines/bf4sa_2026_bob-2.json
+++ b/tests/corpus/baselines/bf4sa_2026_bob-2.json
@@ -1,0 +1,426 @@
+{
+  "data_types": {
+    "chrome:autofill:entry": 22,
+    "chrome:bookmark:entry": 2,
+    "chrome:cache:entry": 13318,
+    "chrome:cookie:entry": 5570,
+    "chrome:extension:installed": 16,
+    "chrome:extension_storage:entry": 19522,
+    "chrome:file_system:entry": 3,
+    "chrome:history:file_downloaded": 31,
+    "chrome:history:page_visited": 545,
+    "chrome:indexeddb:entry": 9116,
+    "chrome:local_storage:entry": 10495,
+    "chrome:login_item:entry": 13,
+    "chrome:preferences:entry": 160,
+    "chrome:service_worker:cache_entry": 2691,
+    "chrome:service_worker:registration": 760,
+    "chrome:service_worker:resource": 1805,
+    "chrome:service_worker:script": 49,
+    "chrome:service_worker:user_data": 2,
+    "chrome:session:closed_tab": 63,
+    "chrome:session:closed_window": 26,
+    "chrome:session:navigation": 562,
+    "chrome:session:tab_closed": 1,
+    "chrome:session:tab_last_active": 32,
+    "chrome:session_storage:entry": 1267,
+    "chrome:site_setting:entry": 1022,
+    "chrome:sync_data:entry": 8354
+  },
+  "generated_by": {
+    "generated_utc": "2026-09-04T17:01:42Z",
+    "hindsight_version": "2026.06"
+  },
+  "profiles": {
+    "Default": {
+      "artifacts": {
+        "Autofill": {
+          "count": 16,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Bookmarks": {
+          "count": 2,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cache": {
+          "count": 6740,
+          "status": "partial",
+          "unparsed_records": 4428,
+          "unparsed_sources": 0
+        },
+        "Cookies": {
+          "count": 5333,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "DIPS": {
+          "count": 20,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "DIPS Popups": {
+          "count": 2,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "DawnGraphiteCache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "DawnWebGPUCache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Cookies": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Rules": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Scripts": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension State": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extensions": {
+          "count": 2,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "File System": {
+          "count": 3,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "GPUCache": {
+          "count": 0,
+          "status": "partial",
+          "unparsed_records": 12,
+          "unparsed_sources": 0
+        },
+        "HSTS": {
+          "count": 408,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History": {
+          "count": 508,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History_downloads": {
+          "count": 8,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "IndexedDB": {
+          "count": 7953,
+          "status": "partial",
+          "unparsed_records": 0,
+          "unparsed_sources": 4
+        },
+        "Local Extension Settings": {
+          "count": 1,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Local Storage": {
+          "count": 10184,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Login Data": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Managed Extension Settings": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Platform Notifications": {
+          "count": 8,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Preferences": {
+          "count": 261,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Secure Preferences": {
+          "count": 8,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Service Workers": {
+          "count": 4184,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Session Storage": {
+          "count": 1164,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sessions": {
+          "count": 491,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Site Characteristics": {
+          "count": 271,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sync App Settings": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sync Data": {
+          "count": 4604,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sync Extension Settings": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "shared_proto_db downloads": {
+          "count": 20,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        }
+      },
+      "browser": "Chrome"
+    },
+    "Profile 1": {
+      "artifacts": {
+        "Autofill": {
+          "count": 6,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Bookmarks": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cache": {
+          "count": 3887,
+          "status": "partial",
+          "unparsed_records": 4,
+          "unparsed_sources": 0
+        },
+        "Cookies": {
+          "count": 237,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "DIPS": {
+          "count": 6,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "DIPS Popups": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "DawnGraphiteCache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "DawnWebGPUCache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Rules": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Scripts": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension State": {
+          "count": 18845,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extensions": {
+          "count": 3,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "GPUCache": {
+          "count": 0,
+          "status": "partial",
+          "unparsed_records": 2,
+          "unparsed_sources": 0
+        },
+        "HSTS": {
+          "count": 54,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History": {
+          "count": 37,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History_downloads": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "IndexedDB": {
+          "count": 1163,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Local Extension Settings": {
+          "count": 676,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Local Storage": {
+          "count": 311,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Login Data": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Platform Notifications": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Preferences": {
+          "count": 104,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Secure Preferences": {
+          "count": 8,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Service Workers": {
+          "count": 1123,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Session Storage": {
+          "count": 103,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sessions": {
+          "count": 193,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Site Characteristics": {
+          "count": 39,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sync Data": {
+          "count": 3750,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "shared_proto_db downloads": {
+          "count": 3,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        }
+      },
+      "browser": "Chrome"
+    }
+  },
+  "root": "bf4sa_2026_bob-2",
+  "total_records": 75447
+}

--- a/tests/corpus/baselines/magnet.ctf_2018.json
+++ b/tests/corpus/baselines/magnet.ctf_2018.json
@@ -1,0 +1,431 @@
+{
+  "data_types": {
+    "chrome:autofill:entry": 80,
+    "chrome:bookmark:entry": 21,
+    "chrome:bookmark:folder": 13,
+    "chrome:cache:entry": 8895,
+    "chrome:cookie:entry": 2217,
+    "chrome:extension:installed": 56,
+    "chrome:file_system:entry": 1,
+    "chrome:history:file_downloaded": 29,
+    "chrome:history:page_visited": 480,
+    "chrome:indexeddb:entry": 126,
+    "chrome:local_storage:entry": 1385,
+    "chrome:login_item:entry": 2,
+    "chrome:preferences:entry": 361,
+    "chrome:service_worker:cache_entry": 8,
+    "chrome:service_worker:registration": 49,
+    "chrome:service_worker:resource": 90,
+    "chrome:service_worker:script": 2,
+    "chrome:session:navigation": 9,
+    "chrome:session_storage:entry": 265,
+    "chrome:site_setting:entry": 135,
+    "chrome:sync_data:entry": 1
+  },
+  "generated_by": {
+    "generated_utc": "2026-09-04T17:01:48Z",
+    "hindsight_version": "2026.06"
+  },
+  "profiles": {
+    "Users/Administrator/AppData/Local/Google/Chrome/User Data/Default": {
+      "artifacts": {
+        "Autofill": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cache": {
+          "count": null,
+          "status": "failed",
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cookies": {
+          "count": 8,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Rules": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension State": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extensions": {
+          "count": 3,
+          "status": "partial",
+          "unparsed_records": 0,
+          "unparsed_sources": 1
+        },
+        "HSTS": {
+          "count": 5,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History": {
+          "count": 2,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History_downloads": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "IndexedDB": {
+          "count": 0,
+          "status": "partial",
+          "unparsed_records": 0,
+          "unparsed_sources": 1
+        },
+        "Login Data": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Preferences": {
+          "count": 8,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Secure Preferences": {
+          "count": 18,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        }
+      },
+      "browser": "Chrome"
+    },
+    "Users/itsupport/AppData/Roaming/Mozilla/Firefox/Profiles/fpck3n2q.default": {
+      "artifacts": {
+        "Bookmarks": {
+          "count": 13,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cache": {
+          "count": 182,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cache API": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cookies": {
+          "count": 31,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extensions": {
+          "count": 10,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Favicons": {
+          "count": 8,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "IndexedDB": {
+          "count": 6,
+          "status": "partial",
+          "unparsed_records": 1,
+          "unparsed_sources": 0
+        },
+        "Local Storage": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Permissions": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Preferences": {
+          "count": 143,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sessions": {
+          "count": 6,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "places.sqlite": {
+          "count": 11,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "places.sqlite_downloads": {
+          "count": 1,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        }
+      },
+      "browser": "Firefox"
+    },
+    "Users/maxpowers/AppData/Local/Google/Chrome/User Data/Default": {
+      "artifacts": {
+        "Autofill": {
+          "count": 52,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cache": {
+          "count": 4163,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cookies": {
+          "count": 1073,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Rules": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension State": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extensions": {
+          "count": 9,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "File System": {
+          "count": 1,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "GPUCache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "HSTS": {
+          "count": 55,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History": {
+          "count": 202,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History_downloads": {
+          "count": 11,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "IndexedDB": {
+          "count": 36,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Local Extension Settings": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Local Storage": {
+          "count": 1385,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Login Data": {
+          "count": 2,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Media Cache": {
+          "count": 16,
+          "status": "partial",
+          "unparsed_records": 57,
+          "unparsed_sources": 0
+        },
+        "Preferences": {
+          "count": 88,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Secure Preferences": {
+          "count": 16,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Service Workers": {
+          "count": 149,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Session Storage": {
+          "count": 265,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sync Data": {
+          "count": 1,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sync Extension Settings": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        }
+      },
+      "browser": "Chrome"
+    },
+    "Users/maxpowers/AppData/Roaming/Mozilla/Firefox/Profiles/dbwuvf2f.default": {
+      "artifacts": {
+        "Bookmark Backups": {
+          "count": 8,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Bookmarks": {
+          "count": 13,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cache": {
+          "count": 4526,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cache API": {
+          "count": 0,
+          "status": "partial",
+          "unparsed_records": 0,
+          "unparsed_sources": 3
+        },
+        "Cookies": {
+          "count": 1105,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extensions": {
+          "count": 12,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Favicons": {
+          "count": 135,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "IndexedDB": {
+          "count": 84,
+          "status": "partial",
+          "unparsed_records": 1,
+          "unparsed_sources": 0
+        },
+        "Local Storage": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Permissions": {
+          "count": 1,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Preferences": {
+          "count": 175,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sessions": {
+          "count": 15,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "formhistory.sqlite": {
+          "count": 28,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "places.sqlite": {
+          "count": 122,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "places.sqlite_downloads": {
+          "count": 17,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        }
+      },
+      "browser": "Firefox"
+    }
+  },
+  "root": "magnet.ctf_2018",
+  "total_records": 14225
+}

--- a/tests/corpus/baselines/magnet.ctf_2019.json
+++ b/tests/corpus/baselines/magnet.ctf_2019.json
@@ -1,0 +1,285 @@
+{
+  "data_types": {
+    "chrome:cache:entry": 7359,
+    "chrome:cookie:entry": 201,
+    "chrome:extension:installed": 32,
+    "chrome:extension_storage:entry": 2,
+    "chrome:history:file_downloaded": 5,
+    "chrome:history:page_visited": 594,
+    "chrome:indexeddb:entry": 76,
+    "chrome:local_storage:entry": 554,
+    "chrome:login_item:entry": 2,
+    "chrome:preferences:entry": 56,
+    "chrome:service_worker:cache_entry": 8,
+    "chrome:service_worker:registration": 25,
+    "chrome:service_worker:resource": 80,
+    "chrome:service_worker:script": 20,
+    "chrome:session_storage:entry": 689,
+    "chrome:site_setting:entry": 87,
+    "chrome:sync_data:entry": 2
+  },
+  "generated_by": {
+    "generated_utc": "2026-09-04T17:01:54Z",
+    "hindsight_version": "2026.06"
+  },
+  "profiles": {
+    "Users/Administrator/AppData/Local/Google/Chrome/User Data/Default": {
+      "artifacts": {
+        "Autofill": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cache": {
+          "count": 309,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cookies": {
+          "count": 107,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Rules": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension State": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extensions": {
+          "count": 9,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "GPUCache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "HSTS": {
+          "count": 17,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History": {
+          "count": 6,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History_downloads": {
+          "count": 3,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Local Extension Settings": {
+          "count": 1,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Local Storage": {
+          "count": 267,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Login Data": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Preferences": {
+          "count": 21,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Secure Preferences": {
+          "count": 16,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Service Workers": {
+          "count": 14,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Session Storage": {
+          "count": 11,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Site Characteristics": {
+          "count": 1,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sync Data": {
+          "count": 1,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sync Extension Settings": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        }
+      },
+      "browser": "Chrome"
+    },
+    "Users/SelmaBouvier/AppData/Local/Google/Chrome/User Data/Default": {
+      "artifacts": {
+        "Autofill": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cache": {
+          "count": 7042,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cookies": {
+          "count": 94,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Rules": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension State": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extensions": {
+          "count": 9,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "GPUCache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "HSTS": {
+          "count": 36,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History": {
+          "count": 588,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History_downloads": {
+          "count": 2,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "IndexedDB": {
+          "count": 76,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Local Extension Settings": {
+          "count": 1,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Local Storage": {
+          "count": 287,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Login Data": {
+          "count": 2,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Preferences": {
+          "count": 35,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Secure Preferences": {
+          "count": 16,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Service Workers": {
+          "count": 119,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Session Storage": {
+          "count": 678,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Site Characteristics": {
+          "count": 8,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sync Data": {
+          "count": 1,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sync Extension Settings": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        }
+      },
+      "browser": "Chrome"
+    }
+  },
+  "root": "magnet.ctf_2019",
+  "total_records": 9792
+}

--- a/tests/corpus/baselines/magnet.ctf_2020.json
+++ b/tests/corpus/baselines/magnet.ctf_2020.json
@@ -1,0 +1,187 @@
+{
+  "data_types": {
+    "chrome:autofill:entry": 76,
+    "chrome:cache:entry": 767,
+    "chrome:cookie:entry": 1024,
+    "chrome:extension:installed": 17,
+    "chrome:extension_storage:entry": 5140,
+    "chrome:file_system:entry": 326,
+    "chrome:history:file_downloaded": 24,
+    "chrome:history:page_visited": 516,
+    "chrome:indexeddb:entry": 2384,
+    "chrome:local_storage:entry": 880,
+    "chrome:login_item:entry": 29,
+    "chrome:preferences:entry": 50,
+    "chrome:service_worker:cache_entry": 679,
+    "chrome:service_worker:registration": 454,
+    "chrome:service_worker:resource": 1045,
+    "chrome:service_worker:script": 29,
+    "chrome:service_worker:user_data": 17,
+    "chrome:session_storage:entry": 880,
+    "chrome:site_setting:entry": 493,
+    "chrome:sync_data:entry": 2486
+  },
+  "generated_by": {
+    "generated_utc": "2026-09-04T17:01:57Z",
+    "hindsight_version": "2026.06"
+  },
+  "profiles": {
+    "Users/Warren/AppData/Local/Google/Chrome/User Data/Default": {
+      "artifacts": {
+        "Autofill": {
+          "count": 76,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Bookmarks": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cache": {
+          "count": 88,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cookies": {
+          "count": 1024,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Rules": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension State": {
+          "count": 5134,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extensions": {
+          "count": 10,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "File System": {
+          "count": 326,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "GPUCache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "HSTS": {
+          "count": 170,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History": {
+          "count": 516,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History_downloads": {
+          "count": 24,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "IndexedDB": {
+          "count": 2384,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Local Extension Settings": {
+          "count": 6,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Local Storage": {
+          "count": 880,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Login Data": {
+          "count": 29,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Platform Notifications": {
+          "count": 82,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Preferences": {
+          "count": 186,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Secure Preferences": {
+          "count": 17,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Service Workers": {
+          "count": 2224,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Session Storage": {
+          "count": 880,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Site Characteristics": {
+          "count": 93,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sync Data": {
+          "count": 2486,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sync Extension Settings": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "shared_proto_db downloads": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        }
+      },
+      "browser": "Chrome"
+    }
+  },
+  "root": "magnet.ctf_2020",
+  "total_records": 17316
+}

--- a/tests/corpus/baselines/magnet.ctf_2023.json
+++ b/tests/corpus/baselines/magnet.ctf_2023.json
@@ -1,0 +1,692 @@
+{
+  "data_types": {
+    "chrome:autofill:entry": 24,
+    "chrome:cache:entry": 19593,
+    "chrome:cookie:entry": 1966,
+    "chrome:extension:installed": 48,
+    "chrome:extension_storage:entry": 2,
+    "chrome:file_system:entry": 2,
+    "chrome:history:file_downloaded": 61,
+    "chrome:history:page_visited": 1099,
+    "chrome:indexeddb:entry": 6978,
+    "chrome:local_storage:entry": 1014,
+    "chrome:login_item:entry": 12,
+    "chrome:preferences:entry": 281,
+    "chrome:service_worker:cache_entry": 948,
+    "chrome:service_worker:registration": 247,
+    "chrome:service_worker:resource": 260,
+    "chrome:service_worker:script": 35,
+    "chrome:session:closed_tab": 51,
+    "chrome:session:closed_window": 28,
+    "chrome:session:navigation": 812,
+    "chrome:session:tab_closed": 5,
+    "chrome:session:tab_last_active": 25,
+    "chrome:session:window_closed": 1,
+    "chrome:session_storage:entry": 756,
+    "chrome:site_setting:entry": 665,
+    "chrome:sync_data:entry": 1732
+  },
+  "generated_by": {
+    "generated_utc": "2026-09-04T17:02:33Z",
+    "hindsight_version": "2026.06"
+  },
+  "profiles": {
+    "Users/borch/AppData/Local/Google/Chrome/User Data/Default": {
+      "artifacts": {
+        "Autofill": {
+          "count": 14,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cache": {
+          "count": 7238,
+          "status": "partial",
+          "unparsed_records": 10,
+          "unparsed_sources": 0
+        },
+        "Cookies": {
+          "count": 522,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "DawnCache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Rules": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Scripts": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension State": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extensions": {
+          "count": 2,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "File System": {
+          "count": 1,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "GPUCache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "HSTS": {
+          "count": 82,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History": {
+          "count": 482,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History_downloads": {
+          "count": 5,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "IndexedDB": {
+          "count": 4751,
+          "status": "partial",
+          "unparsed_records": 0,
+          "unparsed_sources": 1
+        },
+        "Local Extension Settings": {
+          "count": 1,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Local Storage": {
+          "count": 445,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Login Data": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Preferences": {
+          "count": 137,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Secure Preferences": {
+          "count": 6,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Service Workers": {
+          "count": 465,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Session Storage": {
+          "count": 332,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sessions": {
+          "count": 369,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Site Characteristics": {
+          "count": 60,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sync Data": {
+          "count": 189,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "shared_proto_db downloads": {
+          "count": 12,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        }
+      },
+      "browser": "Chrome"
+    },
+    "Users/borch/AppData/Local/Google/Chrome/User Data/Guest Profile": {
+      "artifacts": {
+        "Autofill": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cookies": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Scripts": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension State": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "HSTS": {
+          "count": 1,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History_downloads": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Local Storage": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Login Data": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Preferences": {
+          "count": 15,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Secure Preferences": {
+          "count": 4,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Site Characteristics": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sync Data": {
+          "count": 1,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "shared_proto_db downloads": {
+          "count": 2,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        }
+      },
+      "browser": "Chrome"
+    },
+    "Users/borch/AppData/Local/Google/Chrome/User Data/Profile 2": {
+      "artifacts": {
+        "Autofill": {
+          "count": 10,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Bookmarks": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cache": {
+          "count": 9322,
+          "status": "partial",
+          "unparsed_records": 1763,
+          "unparsed_sources": 0
+        },
+        "Cookies": {
+          "count": 1197,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "DawnCache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Rules": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Scripts": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension State": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extensions": {
+          "count": 2,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "GPUCache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "HSTS": {
+          "count": 151,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History": {
+          "count": 575,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History_downloads": {
+          "count": 18,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "IndexedDB": {
+          "count": 2138,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Local Extension Settings": {
+          "count": 1,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Local Storage": {
+          "count": 460,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Login Data": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Managed Extension Settings": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Preferences": {
+          "count": 184,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Secure Preferences": {
+          "count": 6,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Service Workers": {
+          "count": 716,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Session Storage": {
+          "count": 336,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sessions": {
+          "count": 521,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Site Characteristics": {
+          "count": 76,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sync Data": {
+          "count": 1504,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "shared_proto_db downloads": {
+          "count": 20,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        }
+      },
+      "browser": "Chrome"
+    },
+    "Users/borch/AppData/Local/Google/Chrome/User Data/System Profile": {
+      "artifacts": {
+        "Autofill": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cookies": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Rules": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Scripts": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension State": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "HSTS": {
+          "count": 1,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History_downloads": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Local Storage": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Login Data": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Preferences": {
+          "count": 15,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Secure Preferences": {
+          "count": 4,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Site Characteristics": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sync Data": {
+          "count": 1,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "shared_proto_db downloads": {
+          "count": 2,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        }
+      },
+      "browser": "Chrome"
+    },
+    "Users/borch/AppData/Local/Microsoft/Edge/User Data/Default": {
+      "artifacts": {
+        "Autofill": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Cache": {
+          "count": 2085,
+          "status": "partial",
+          "unparsed_records": 2,
+          "unparsed_sources": 0
+        },
+        "Cookies": {
+          "count": 247,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "DawnCache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension Scripts": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Extension State": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "File System": {
+          "count": 1,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "GPUCache": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "HSTS": {
+          "count": 77,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History": {
+          "count": 42,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "History_downloads": {
+          "count": 1,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "IndexedDB": {
+          "count": 89,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Local Extension Settings": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Local Storage": {
+          "count": 109,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Login Data": {
+          "count": 0,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Preferences": {
+          "count": 125,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Secure Preferences": {
+          "count": 28,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Service Workers": {
+          "count": 309,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Session Storage": {
+          "count": 88,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sessions": {
+          "count": 32,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Site Characteristics": {
+          "count": 17,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "Sync Data": {
+          "count": 37,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        },
+        "shared_proto_db downloads": {
+          "count": 1,
+          "status": null,
+          "unparsed_records": 0,
+          "unparsed_sources": 0
+        }
+      },
+      "browser": "Edge"
+    }
+  },
+  "root": "magnet.ctf_2023",
+  "total_records": 36645
+}

--- a/tests/corpus/generate_baselines.py
+++ b/tests/corpus/generate_baselines.py
@@ -1,0 +1,67 @@
+"""Regenerate the corpus baselines.
+
+    python tests/corpus/generate_baselines.py --corpus D:/hindsight/github-test-data
+
+Run this deliberately, never to make a red build green. A baseline changing means real
+parse output changed: either a parser improved (regenerate, and say what moved in the
+commit message) or something broke (do not regenerate). The whole value of these files
+is that they make that difference visible, and regenerating on autopilot throws it away.
+
+With no root names it does every root the corpus holds. Name roots to do a subset:
+
+    python tests/corpus/generate_baselines.py magnet.ctf_2019
+"""
+
+import argparse
+import os
+import pathlib
+import sys
+import time
+
+# Run as a script, so the repo root is not on the path yet; both pyhindsight and the
+# tests package are imported from there.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+import pyhindsight
+from tests.corpus.runner import run_root, write_baseline
+
+BASELINE_DIR = pathlib.Path(__file__).resolve().parent / 'baselines'
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('roots', nargs='*',
+                        help='root directory names; default is every root present')
+    parser.add_argument('--corpus', default=os.environ.get('HINDSIGHT_TEST_CORPUS'),
+                        help='corpus directory (default: $HINDSIGHT_TEST_CORPUS)')
+    args = parser.parse_args()
+
+    if not args.corpus:
+        parser.error('no corpus path; pass --corpus or set HINDSIGHT_TEST_CORPUS')
+    corpus = pathlib.Path(args.corpus)
+    if not corpus.is_dir():
+        parser.error(f'corpus directory does not exist: {corpus}')
+
+    names = args.roots or sorted(p.name for p in corpus.iterdir() if p.is_dir())
+    BASELINE_DIR.mkdir(parents=True, exist_ok=True)
+
+    total_started = time.time()
+    for name in names:
+        root = corpus / name
+        if not root.is_dir():
+            print(f'  {name}: not in the corpus, skipped')
+            continue
+        started = time.time()
+        baseline = run_root(root)
+        destination = BASELINE_DIR / f'{name}.json'
+        write_baseline(baseline, destination, pyhindsight.__version__)
+        print(f'  {name}: {baseline["total_records"]} records, '
+              f'{len(baseline["profiles"])} profiles, '
+              f'{len(baseline["data_types"])} data types, '
+              f'{time.time() - started:.0f}s -> {destination.name}')
+    print(f'total {time.time() - total_started:.0f}s')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/corpus/runner.py
+++ b/tests/corpus/runner.py
@@ -1,0 +1,166 @@
+"""Run Hindsight over a corpus root and reduce the result to a comparable baseline.
+
+The manual procedure this replaces: parse a set of real profiles before and after a
+change, then diff the counts, labels and statuses. That has caught things no unit test
+did (a whole Session Storage artifact vanishing on Windows, four parsers silently
+dropping stores), and it existed only as something a human remembered to do.
+
+Shared by `generate_baselines.py` and `tests/test_corpus_e2e.py`, so the numbers a
+baseline records and the numbers a test compares are produced by the same code.
+
+Plugins are deliberately not run. They add `interpretation` values, and at least one
+makes an outbound network call, so including them would make the baseline depend on a
+third party being up and unchanged.
+"""
+
+import collections
+import datetime
+import json
+import os
+import pathlib
+import tempfile
+import zoneinfo
+
+from pyhindsight.analysis import AnalysisSession
+from pyhindsight.artifact_filter import ArtifactFilter
+
+
+def _relative_profile(profile_path, root):
+    """Profile path as a stable, portable key.
+
+    `artifact_results` is keyed by the absolute path the run was given, which differs on
+    every machine and between operating systems. Baselines have to survive that, so the
+    key becomes a forward-slashed path relative to the corpus root.
+    """
+    normalized = str(profile_path).replace('\\', '/')
+    root = str(root).replace('\\', '/').rstrip('/')
+    if normalized.startswith(root):
+        normalized = normalized[len(root):]
+    return normalized.strip('/')
+
+
+def run_root(root, temp_dir=None):
+    """Parse one corpus root and return its baseline as a plain dict.
+
+    `root` is a directory Hindsight is pointed at; it finds the profiles beneath it. One
+    root can hold several profiles and more than one browser, which is the point: it
+    exercises recursive discovery and mixed-browser dispatch as well as the parsers.
+    """
+    root = pathlib.Path(root)
+    session = AnalysisSession()
+    session.input_path = str(root)
+    session.selected_output_format = 'jsonl'
+    session.artifact_filter = ArtifactFilter.from_selectors(None, None)
+    session.browser_type = None
+    session.timezone = zoneinfo.ZoneInfo('UTC')
+    session.no_copy = False
+
+    with tempfile.TemporaryDirectory(dir=temp_dir) as scratch:
+        session.temp_dir = os.path.join(scratch, 'temp')
+        session.log_path = os.path.join(scratch, 'hindsight.log')
+        session.output_name = os.path.join(scratch, 'out')
+
+        if not session.run():
+            raise RuntimeError(f'{root.name}: run failed ({session.fatal_error})')
+
+        # data_type is assigned by the JSONL encoder rather than carried on the item, so
+        # counting it means writing the output. Per-data_type counts are what caught the
+        # Session Storage regression: the total alone moved by less than 2%.
+        jsonl_path = os.path.join(scratch, 'out.jsonl')
+        session.generate_jsonl(jsonl_path)
+        data_types = collections.Counter()
+        total = 0
+        with open(jsonl_path, encoding='utf-8') as f:
+            for line in f:
+                if line.strip():
+                    data_types[json.loads(line).get('data_type', '<none>')] += 1
+                    total += 1
+
+    profiles = {}
+    for profile_path, results in session.artifact_results.items():
+        key = _relative_profile(profile_path, root)
+        profiles[key] = {
+            'browser': session.detected_profile_families.get(profile_path),
+            'artifacts': {
+                name: {
+                    'count': result.count,
+                    'status': result.status,
+                    'unparsed_sources': result.unparsed_sources,
+                    'unparsed_records': result.unparsed_records,
+                }
+                for name, result in sorted(results.items())
+            },
+        }
+
+    return {
+        'root': root.name,
+        'total_records': total,
+        'data_types': dict(sorted(data_types.items())),
+        'profiles': dict(sorted(profiles.items())),
+    }
+
+
+def diff(expected, actual):
+    """Return a list of human-readable differences, empty when the two agree.
+
+    Deliberately verbose about *what* moved rather than dumping both dicts: the useful
+    output of a failure is "chrome:session_storage:entry 678 -> 0", which names the
+    artifact to go and look at.
+    """
+    problems = []
+
+    if expected['total_records'] != actual['total_records']:
+        problems.append(
+            f"total records {expected['total_records']} -> {actual['total_records']}")
+
+    exp_types, act_types = expected['data_types'], actual['data_types']
+    for name in sorted(set(exp_types) | set(act_types)):
+        before, after = exp_types.get(name, 0), act_types.get(name, 0)
+        if before != after:
+            problems.append(f'{name} {before} -> {after}')
+
+    exp_profiles, act_profiles = expected['profiles'], actual['profiles']
+    for missing in sorted(set(exp_profiles) - set(act_profiles)):
+        problems.append(f'profile no longer found: {missing}')
+    for added in sorted(set(act_profiles) - set(exp_profiles)):
+        problems.append(f'unexpected profile: {added}')
+
+    for name in sorted(set(exp_profiles) & set(act_profiles)):
+        before, after = exp_profiles[name], act_profiles[name]
+        if before['browser'] != after['browser']:
+            problems.append(
+                f"{name}: detected as {before['browser']} -> {after['browser']}")
+        exp_art, act_art = before['artifacts'], after['artifacts']
+        for gone in sorted(set(exp_art) - set(act_art)):
+            problems.append(f'{name}: artifact no longer reported: {gone}')
+        for new in sorted(set(act_art) - set(exp_art)):
+            problems.append(f'{name}: new artifact reported: {new}')
+        for artifact in sorted(set(exp_art) & set(act_art)):
+            for field in ('count', 'status', 'unparsed_sources', 'unparsed_records'):
+                b, a = exp_art[artifact][field], act_art[artifact][field]
+                if b != a:
+                    problems.append(f'{name}: {artifact} {field} {b} -> {a}')
+
+    return problems
+
+
+def write_baseline(baseline, path, hindsight_version):
+    """Write a baseline, stamped with what produced it.
+
+    The version and date are provenance for a human reading a diff; `diff()` never
+    compares them, because a version bump is not a regression.
+    """
+    payload = dict(baseline)
+    payload['generated_by'] = {
+        'hindsight_version': hindsight_version,
+        'generated_utc': datetime.datetime.now(datetime.timezone.utc)
+                                 .strftime('%Y-%m-%dT%H:%M:%SZ'),
+    }
+    with open(path, 'w', encoding='utf-8', newline='\n') as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+        f.write('\n')
+
+
+def load_baseline(path):
+    with open(path, encoding='utf-8') as f:
+        return json.load(f)

--- a/tests/test_corpus_e2e.py
+++ b/tests/test_corpus_e2e.py
@@ -1,0 +1,123 @@
+"""End-to-end parses of real browser profiles, compared to committed baselines.
+
+Every other test in this suite builds its own fixture. That catches logic errors and
+misses the thing real profiles are full of: schemas from 2018, half-written LevelDBs,
+databases missing a column the query names. The checks that have actually caught
+regressions here were whole-profile parses diffed by hand, and this is that procedure
+written down.
+
+Needs a corpus, so it skips unless HINDSIGHT_TEST_CORPUS points at one:
+
+    HINDSIGHT_TEST_CORPUS=D:/hindsight/github-test-data pytest tests/test_corpus_e2e.py
+
+Skipping rather than failing is deliberate: the corpus is several GB and cannot be
+committed, so the ordinary `pytest tests/` a contributor runs must stay green without
+it. What must not happen is CI thinking it ran these and quietly running nothing, which
+`test_the_corpus_is_complete` exists to prevent.
+
+Baselines live in tests/corpus/baselines/ and are regenerated with
+tests/corpus/generate_baselines.py. See that file before regenerating anything.
+"""
+
+import os
+import pathlib
+import unittest
+
+from tests.corpus.runner import diff, load_baseline, run_root
+
+CORPUS = os.environ.get('HINDSIGHT_TEST_CORPUS')
+BASELINE_DIR = pathlib.Path(__file__).resolve().parent / 'corpus' / 'baselines'
+
+# CI shards one root per job, so each job holds only the root it is testing. Without
+# this the completeness check would fail every shard for the five roots it was never
+# given. Unset means "every baseline", which is what a local run wants.
+SELECTED = [r.strip() for r in os.environ.get('HINDSIGHT_TEST_CORPUS_ROOTS', '').split(',')
+            if r.strip()]
+
+
+def baselines():
+    found = sorted(BASELINE_DIR.glob('*.json'))
+    if SELECTED:
+        found = [p for p in found if p.stem in SELECTED]
+    return found
+
+
+@unittest.skipUnless(CORPUS, 'set HINDSIGHT_TEST_CORPUS to a corpus directory')
+class TestCorpusParses(unittest.TestCase):
+    """A parse of each corpus root still produces what it produced before.
+
+    A failure here is not automatically a bug: a parser improvement moves these numbers
+    too. It means output changed and someone has to say which of the two it was.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.corpus = pathlib.Path(CORPUS)
+        if not cls.corpus.is_dir():
+            raise unittest.SkipTest(f'HINDSIGHT_TEST_CORPUS is not a directory: {CORPUS}')
+        if not baselines():
+            raise unittest.SkipTest(f'no baselines in {BASELINE_DIR}')
+
+    def test_the_corpus_is_complete(self):
+        """Every baseline has its data present.
+
+        Without this, a corpus that failed to download leaves every root skipped and the
+        job green, which is the worst outcome available: it reports that end-to-end
+        parses passed when none ran.
+        """
+        missing = [p.stem for p in baselines() if not (self.corpus / p.stem).is_dir()]
+        self.assertEqual([], missing,
+                         f'baselines exist for roots not in {self.corpus}: {missing}')
+        unknown = sorted(set(SELECTED) - {p.stem for p in BASELINE_DIR.glob('*.json')})
+        self.assertEqual([], unknown,
+                         f'HINDSIGHT_TEST_CORPUS_ROOTS names roots with no baseline: '
+                         f'{unknown}')
+
+    def test_each_root_matches_its_baseline(self):
+        for path in baselines():
+            root = self.corpus / path.stem
+            with self.subTest(root=path.stem):
+                if not root.is_dir():
+                    self.skipTest(f'{path.stem} not in the corpus')
+                problems = diff(load_baseline(path), run_root(root))
+                self.assertEqual(
+                    [], problems,
+                    f'\n{path.stem} no longer parses to its baseline:\n  '
+                    + '\n  '.join(problems)
+                    + f'\n\nIf this is an intended parser change, regenerate with:\n'
+                      f'  python tests/corpus/generate_baselines.py {path.stem}\n'
+                      f'and say in the commit message what moved and why.')
+
+
+class TestBaselinesAreUsable(unittest.TestCase):
+    """Checks on the baseline files themselves, which need no corpus."""
+
+    def test_baselines_exist(self):
+        self.assertTrue(baselines(), f'no baseline files in {BASELINE_DIR}')
+
+    def test_every_baseline_has_the_expected_shape(self):
+        for path in baselines():
+            with self.subTest(baseline=path.name):
+                baseline = load_baseline(path)
+                self.assertEqual(path.stem, baseline['root'])
+                self.assertGreater(baseline['total_records'], 0)
+                self.assertTrue(baseline['data_types'])
+                self.assertTrue(baseline['profiles'])
+                self.assertEqual(
+                    baseline['total_records'], sum(baseline['data_types'].values()),
+                    'total_records disagrees with the sum of its data_types')
+
+    def test_profile_keys_are_portable(self):
+        # A baseline generated on Windows has to compare on a Linux runner, so no drive
+        # letters and no backslashes.
+        for path in baselines():
+            baseline = load_baseline(path)
+            for profile in baseline['profiles']:
+                with self.subTest(baseline=path.name, profile=profile):
+                    self.assertNotIn('\\', profile)
+                    self.assertNotIn(':', profile)
+                    self.assertFalse(profile.startswith('/'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds end-to-end parse tests: run Hindsight over real browser profiles and compare the result to committed baselines.                                                                                                 

A baseline records three layers: total records, per-data_type counts, and per-profile per-artifact count, status and unparsed totals. 

The corpus is 6 roots, 16 profiles, ~220k records, covering Chrome from 2018 to 2026 plus Firefox and Edge. It lives as release assets on RyanDFIR/data-sets and is fetched by plain URL with no token, so a pull request from a fork gets the same coverage as a branch here.

Runs on every pull request and on push to main, sharded one job per root so a failure names which root changed rather than showing one opaque red tick. Without a corpus the tests skip, so pytest tests/ stays green for anyone without the data, and test_the_corpus_is_complete stops CI from passing while silently parsing nothing.                                                                                            