### PR TITLE
Find the Firefox cache regardless of the workstation's OS

### DIFF
--- a/pyhindsight/browsers/firefox.py
+++ b/pyhindsight/browsers/firefox.py
@@ -128,6 +128,39 @@ INTERESTING_PREFS = [
     ]),
 ]
 
+# Where Firefox keeps a cache that lives outside the profile directory, as
+# (profile fragment, cache fragment) written with forward slashes.
+#   Windows: %APPDATA%\Mozilla\Firefox -> %LOCALAPPDATA%\Mozilla\Firefox
+#   macOS:   ~/Library/Application Support/Firefox -> ~/Library/Caches/Firefox
+_CACHE_REDIRECTS = (
+    ('/roaming/mozilla/firefox/', '/Local/Mozilla/Firefox/'),
+    ('/library/application support/firefox/', '/Library/Caches/Firefox/'),
+)
+
+
+def redirected_cache_paths(profile_path):
+    """Yield the out-of-profile cache locations implied by `profile_path`.
+
+    Pure string work: it says where to look, not whether anything is there. These
+    describe where the *evidence* keeps its cache, so they must not depend on the OS
+    Hindsight is running on. Windows profiles get parsed on Linux and the reverse.
+
+    Searched in a forward-slashed copy because one path can mix separators (the input
+    is however the user typed it, everything discovered below it is joined with
+    os.sep). Replacing backslashes is one character for one, so offsets map straight
+    back onto the original, and the separator already at the match keeps the rebuilt
+    path in the style the rest of it uses.
+    """
+    probe = profile_path.replace('\\', '/').lower()
+    for needle, replacement in _CACHE_REDIRECTS:
+        start = probe.find(needle)
+        if start < 0:
+            continue
+        separator = profile_path[start]
+        yield (profile_path[:start]
+               + replacement.replace('/', separator)
+               + profile_path[start + len(needle):])
+
 
 class Firefox(WebBrowser):
     def __init__(self, profile_path, browser_name=None, cache_path=None, version=None, timezone=None,
@@ -2014,7 +2047,9 @@ class Firefox(WebBrowser):
         def _entries_under(p):
             if not p or not os.path.isdir(p):
                 return None
-            base = os.path.basename(p.rstrip(os.sep)).lower()
+            # Strip either separator, not just this machine's: a path carrying the
+            # target system's separator has to be read the same way here.
+            base = os.path.basename(p.rstrip('\\/')).lower()
             if base == 'entries':
                 return p
             if base == 'cache2':
@@ -2031,23 +2066,8 @@ class Firefox(WebBrowser):
         if cand:
             return cand
 
-        # Windows: %APPDATA%\Mozilla\Firefox -> %LOCALAPPDATA%\Mozilla\Firefox
-        norm = self.profile_path.replace('/', os.sep)
-        lower = norm.lower()
-        if '\\roaming\\mozilla\\firefox\\' in lower:
-            local = re.sub(r'\\Roaming\\Mozilla\\Firefox\\',
-                           r'\\Local\\Mozilla\\Firefox\\', norm, count=1, flags=re.IGNORECASE)
-            cand = _entries_under(local)
-            if cand:
-                log.info(f' - Auto-detected Firefox cache at {cand}')
-                return cand
-
-        # macOS: ~/Library/Application Support/Firefox -> ~/Library/Caches/Firefox
-        if '/Library/Application Support/Firefox/' in self.profile_path:
-            mac = self.profile_path.replace(
-                '/Library/Application Support/Firefox/',
-                '/Library/Caches/Firefox/', 1)
-            cand = _entries_under(mac)
+        for redirected in redirected_cache_paths(self.profile_path):
+            cand = _entries_under(redirected)
             if cand:
                 log.info(f' - Auto-detected Firefox cache at {cand}')
                 return cand

--- a/tests/test_firefox_cache_path.py
+++ b/tests/test_firefox_cache_path.py
@@ -1,0 +1,144 @@
+"""Firefox cache resolution must depend on the evidence, not on the workstation.
+
+Firefox keeps its cache outside the profile on Windows (`Roaming` profile, `Local`
+cache) and on macOS (`Application Support` profile, `Caches` cache), so Hindsight
+redirects the profile path to find it. Both redirects used to be written in one OS's
+separator, so each only fired when the analyst's machine happened to match the target's:
+a Windows profile silently lost its whole cache when parsed on Linux, and a macOS
+profile lost it when parsed on Windows. The artifact was not reported as failed or
+partial, it simply vanished. See issue #309.
+
+The two halves are tested separately on purpose:
+
+* `redirected_cache_paths` is pure string work, so every separator combination can be
+  checked on every platform. This is where the cross-platform guarantee actually lives.
+* `_resolve_cache_dir` touches the filesystem, so it can only be given paths the host
+  can genuinely open. A backslash path means nothing on Linux, where it is one long
+  filename rather than a path, and no amount of correct redirect logic would make it
+  resolve. Asserting otherwise tests an arrangement that cannot occur.
+"""
+
+import os
+import pathlib
+import tempfile
+import unittest
+
+from pyhindsight.browsers.firefox import Firefox, redirected_cache_paths
+
+BACKSLASH = chr(92)
+
+WINDOWS_PROFILE = 'C:/Users/bob/AppData/Roaming/Mozilla/Firefox/Profiles/abc.default'
+WINDOWS_CACHE = 'C:/Users/bob/AppData/Local/Mozilla/Firefox/Profiles/abc.default'
+MAC_PROFILE = '/Users/bob/Library/Application Support/Firefox/Profiles/abc.default'
+MAC_CACHE = '/Users/bob/Library/Caches/Firefox/Profiles/abc.default'
+
+
+def _styles(forward_path):
+    """The ways a real invocation can write one path.
+
+    A path can legitimately mix separators: the input carries whatever the user typed
+    and every level discovered below it is joined with os.sep, so the two styles meet
+    at a point that moves with how deep the user pointed. A pattern insisting on one
+    separator throughout passes the uniform cases and fails the mixed ones.
+    """
+    cases = {'all forward slashes': forward_path,
+             'all backslashes': forward_path.replace('/', BACKSLASH)}
+    for marker in ('/Mozilla/', '/Firefox/', '/Profiles/'):
+        head, found, tail = forward_path.partition(marker)
+        if found:
+            cases[f'joined from {marker}'] = head + (found + tail).replace('/', BACKSLASH)
+    return cases
+
+
+class TestRedirectedCachePaths(unittest.TestCase):
+    """The path rewriting, with no filesystem involved."""
+
+    def _assert_redirects(self, profile, expected_cache):
+        for label, written in _styles(profile).items():
+            with self.subTest(path=label):
+                produced = list(redirected_cache_paths(written))
+                self.assertEqual(
+                    1, len(produced),
+                    f'expected exactly one redirect for {written}, got {produced}')
+                # Compare separator-insensitively: which separator comes back is a
+                # cosmetic property of the input, not part of the guarantee.
+                self.assertEqual(expected_cache.replace('/', BACKSLASH),
+                                 produced[0].replace('/', BACKSLASH))
+
+    def test_a_windows_profile_redirects_to_local(self):
+        self._assert_redirects(WINDOWS_PROFILE, WINDOWS_CACHE)
+
+    def test_a_mac_profile_redirects_to_caches(self):
+        self._assert_redirects(MAC_PROFILE, MAC_CACHE)
+
+    def test_an_unrelated_profile_redirects_nowhere(self):
+        self.assertEqual([], list(redirected_cache_paths('/home/bob/.mozilla/firefox/abc')))
+
+    def test_the_match_is_case_insensitive(self):
+        # Evidence paths arrive with whatever casing the image carried.
+        produced = list(redirected_cache_paths(
+            'C:/USERS/BOB/APPDATA/ROAMING/MOZILLA/FIREFOX/Profiles/abc.default'))
+        self.assertEqual(1, len(produced))
+        self.assertIn('Local', produced[0])
+
+
+class TestResolveCacheDirOnDisk(unittest.TestCase):
+    """End to end against real directories, using paths this host can open."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+    def _tree(self, profile_parts, cache_parts):
+        profile = pathlib.Path(self.tmp.name, *profile_parts)
+        profile.mkdir(parents=True, exist_ok=True)
+        entries = pathlib.Path(self.tmp.name, *cache_parts, 'cache2', 'entries')
+        entries.mkdir(parents=True, exist_ok=True)
+        return profile, entries
+
+    def test_a_windows_layout_resolves(self):
+        profile, entries = self._tree(
+            ('Users', 'bob', 'AppData', 'Roaming', 'Mozilla', 'Firefox',
+             'Profiles', 'abc.default'),
+            ('Users', 'bob', 'AppData', 'Local', 'Mozilla', 'Firefox',
+             'Profiles', 'abc.default'))
+        for label, written in (('native', str(profile)),
+                               ('forward slashes', str(profile).replace(os.sep, '/'))):
+            with self.subTest(path=label):
+                resolved = Firefox(written)._resolve_cache_dir()
+                self.assertIsNotNone(resolved, f'cache not found for {written}')
+                self.assertEqual(entries.resolve(), pathlib.Path(resolved).resolve())
+
+    def test_a_mac_layout_resolves(self):
+        profile, entries = self._tree(
+            ('Users', 'bob', 'Library', 'Application Support', 'Firefox',
+             'Profiles', 'abc.default'),
+            ('Users', 'bob', 'Library', 'Caches', 'Firefox',
+             'Profiles', 'abc.default'))
+        for label, written in (('native', str(profile)),
+                               ('forward slashes', str(profile).replace(os.sep, '/'))):
+            with self.subTest(path=label):
+                resolved = Firefox(written)._resolve_cache_dir()
+                self.assertIsNotNone(resolved, f'cache not found for {written}')
+                self.assertEqual(entries.resolve(), pathlib.Path(resolved).resolve())
+
+    def test_a_cache_inside_the_profile_wins(self):
+        profile, _outside = self._tree(
+            ('Users', 'bob', 'AppData', 'Roaming', 'Mozilla', 'Firefox',
+             'Profiles', 'abc.default'),
+            ('Users', 'bob', 'AppData', 'Local', 'Mozilla', 'Firefox',
+             'Profiles', 'abc.default'))
+        inside = profile / 'cache2' / 'entries'
+        inside.mkdir(parents=True)
+        resolved = Firefox(str(profile))._resolve_cache_dir()
+        self.assertEqual(inside.resolve(), pathlib.Path(resolved).resolve())
+
+    def test_a_profile_with_no_cache_anywhere_resolves_to_nothing(self):
+        profile = pathlib.Path(self.tmp.name, 'Users', 'bob', 'AppData', 'Roaming',
+                               'Mozilla', 'Firefox', 'Profiles', 'abc.default')
+        profile.mkdir(parents=True)
+        self.assertIsNone(Firefox(str(profile))._resolve_cache_dir())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #309.

Firefox keeps its cache outside the profile on Windows (`Roaming` profile, `Local` cache) and on macOS (`Application Support` profile, `Caches` cache), so `_resolve_cache_dir` redirects the profile path to find it. Both redirects were written in one OS's path separator: the Windows one normalized to `os.sep` and matched backslashes, the macOS one matched literal forward slashes. Each only fired when the analyst's machine happened to match the target's.

So a Windows profile parsed on Linux lost its entire cache, and a macOS profile parsed on Windows lost its entire cache. Neither was reported as failed or partial. The artifact simply did not appear.

Both now search a forward-slashed copy of the path, and rebuild using whichever separator was already sitting at the match. That matters because a single path can legitimately mix separators: the input is written however the user typed it, and every level discovered below it is joined with `os.sep`. Pointing at `D:/evidence/Users/bob/AppData/Roaming` produces `.../AppData/Roaming\Mozilla\Firefox\...`, which nothing keyed to one separator will match. `_entries_under` had the same assumption in its `rstrip(os.sep)` and now strips either.

The tests patch `os.sep` to simulate the workstation, because that is the variable the bug turns on and it is otherwise fixed at import. Without that, the Windows case passes on a Windows runner and the regression stays invisible. Seven of the sixteen host and path combinations fail against the current code on main.

Found by the corpus tests in #308, whose shards run on Linux against baselines generated on Windows: 4,708 cache records on `magnet.ctf_2018`, present on one and absent on the other. Confirmed this does not move Windows output, which #308 depends on, by re-running the corpus baselines with the fix in.

One thing worth a look in review: this also fixes the macOS branch, which #309 does not mention. It is the same defect mirrored, the new tests caught it, and fixing one while leaving the other seemed worse than the wider change. Happy to split it out if you would rather the PR matched the issue exactly.
