### PR TITLE
Hash cache bodies and File System backing files

### DIFF
--- a/pyhindsight/analysis.py
+++ b/pyhindsight/analysis.py
@@ -1575,7 +1575,7 @@ class AnalysisSession(object):
         w.merge_range('A1:I1', f'Hindsight Internet History Forensics (v{__version__}) - Timeline', title_header_format)
         w.merge_range('J1:W1', 'URL Visit Specific', center_header_format)
         w.merge_range('X1:AC1', 'Download Specific', center_header_format)
-        w.merge_range('AD1:AF1', 'Cache Specific', center_header_format)
+        w.merge_range('AD1:AG1', 'Cache Specific', center_header_format)
 
         # Write column headers
         w.write(1, 0, 'Type', header_format)
@@ -1610,6 +1610,7 @@ class AnalysisSession(object):
         w.write(1, 29, 'ETag', header_format)
         w.write(1, 30, 'Last Modified', header_format)
         w.write(1, 31, 'All HTTP Headers', header_format)
+        w.write(1, 32, 'Body SHA256', header_format)
 
         # Set column widths
         w.set_column('A:A', 16)  # Type
@@ -1647,6 +1648,7 @@ class AnalysisSession(object):
 
         # Cache Specific
         w.set_column('AF:AF', 30)  # HTTP Headers
+        w.set_column('AG:AG', 66)  # Body SHA256 (64 hex characters)
 
         # Start at the row after the headers and begin writing out the items in parsed_artifacts
         row_number = 2
@@ -1774,6 +1776,7 @@ class AnalysisSession(object):
                     w.write(row_number, 29, item.etag, gray_value_format)  # ETag
                     w.write(row_number, 30, item.last_modified, gray_value_format)  # Last Modified
                     w.write(row_number, 31, item.http_headers_str, gray_value_format)  # headers
+                    w.write(row_number, 32, item.body_sha256, gray_value_format)  # Body SHA256
 
                 elif item.row_type.startswith("local storage"):
                     w.write_string(row_number, 0, item.row_type, gray_type_format)  # record_type
@@ -1939,7 +1942,7 @@ class AnalysisSession(object):
         w.freeze_panes(2, 0)  # Freeze top row
         # Items with no usable timestamp are sorted to the end (see timeline_sort_key)
         # rather than dated to the epoch and hidden, so no row filter is applied here.
-        w.autofilter(1, 0, row_number, 31)  # Add autofilter
+        w.autofilter(1, 0, row_number, 32)  # Add autofilter
 
         ##############################
         # Storage worksheet
@@ -1949,7 +1952,7 @@ class AnalysisSession(object):
         # Title bar
         s.merge_range('A1:G1', f'Hindsight Internet History Forensics (v{__version__}) - Storage', title_header_format)
         s.merge_range('H1:K1', 'Backing Database Specific', center_header_format)
-        s.merge_range('L1:N1', 'FileSystem Specific', center_header_format)
+        s.merge_range('L1:O1', 'FileSystem Specific', center_header_format)
 
         # Write column headers
         s.write(1, 0, 'Type', header_format)
@@ -1966,6 +1969,7 @@ class AnalysisSession(object):
         s.write(1, 11, 'File Exists?', header_format)
         s.write(1, 12, 'File Size (bytes)', header_format)
         s.write(1, 13, 'File Type (Confidence %)', header_format)
+        s.write(1, 14, 'File SHA256', header_format)
 
         # Set column widths
         s.set_column('A:A', 16)  # Type
@@ -1982,6 +1986,7 @@ class AnalysisSession(object):
         s.set_column('L:L', 8)   # Exists
         s.set_column('M:M', 16)  # Size
         s.set_column('N:N', 25)  # Type
+        s.set_column('O:O', 66)  # SHA256 (64 hex characters)
 
         # Start at the row after the headers, and begin writing out the items in parsed_artifacts
         row_number = 2
@@ -2004,6 +2009,7 @@ class AnalysisSession(object):
                     s.write(row_number, 11, item.file_exists, black_value_format)
                     s.write(row_number, 12, item.file_size, black_value_format)
                     s.write(row_number, 13, item.magic_results, black_value_format)
+                    s.write(row_number, 14, item.file_sha256, black_value_format)
 
                 elif item.row_type.startswith(("local storage", "session storage")):
                     s.write_string(row_number, 0, item.row_type, black_type_format)
@@ -2048,7 +2054,9 @@ class AnalysisSession(object):
 
         # Formatting
         s.freeze_panes(2, 0)  # Freeze top row
-        s.autofilter(1, 0, row_number, 12)  # Add autofilter
+        # 14, not 12: the range stopped short of File Type before the SHA256 column
+        # was added, leaving the last column(s) outside the filter.
+        s.autofilter(1, 0, row_number, 14)  # Add autofilter
 
         #########################################
         # Service Workers worksheet
@@ -3108,13 +3116,17 @@ class AnalysisSession(object):
                 'visit_id INT, from_visit INT, opener_visit INT, '
                 'visit_duration TEXT, visit_count INT, typed_count INT, url_hidden INT, transition TEXT, '
                 'interrupt_reason TEXT, danger_type TEXT, opened INT, etag TEXT, last_modified TEXT, http_headers TEXT, '
-                'mime_type TEXT, referrer TEXT, tab_url TEXT, download_source TEXT, hash TEXT, guid TEXT)')
+                # `hash` is the download hash Chrome recorded; body_sha256 is computed by
+                # Hindsight over the cached bytes. Separate columns because separate
+                # provenance: one is evidence, the other is a measurement of it.
+                'mime_type TEXT, referrer TEXT, tab_url TEXT, download_source TEXT, hash TEXT, guid TEXT, '
+                'body_sha256 TEXT)')
 
             c.execute(
                 'CREATE TABLE storage(type TEXT, origin TEXT, key TEXT, value TEXT, '
                 'modification_time TEXT, interpretation TEXT, profile TEXT, source_path TEXT, '
                 'database TEXT, seq INT, state INT, state_friendly TEXT, file_exists BOOL, file_size INT, '
-                'magic_results TEXT)')
+                'magic_results TEXT, file_sha256 TEXT)')
 
             c.execute(
                 'CREATE TABLE installed_extensions(name TEXT, description TEXT, version TEXT, ext_id TEXT, '
@@ -3245,11 +3257,12 @@ class AnalysisSession(object):
                 elif item.row_type.startswith('cache'):
                     c.execute(
                         'INSERT INTO timeline (type, timestamp, url, title, value, interpretation, profile, source_item, '
-                        'etag, last_modified, http_headers)'
-                        'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                        'etag, last_modified, http_headers, body_sha256)'
+                        'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
                         (item.row_type, sql_date(friendly_date(item.timestamp)), item.url, item.data_summary,
                          item.locations, item.interpretation, item.profile, item.source_item,
-                         item.etag, sql_date(item.last_modified), item.http_headers_str))
+                         item.etag, sql_date(item.last_modified), item.http_headers_str,
+                         item.body_sha256))
 
                 elif item.row_type.startswith('login'):
                     c.execute(
@@ -3288,12 +3301,12 @@ class AnalysisSession(object):
                     c.execute(
                         'INSERT INTO storage (type, origin, key, value, modification_time, '
                         'interpretation, profile, source_path, seq, state, state_friendly, file_exists, file_size, '
-                        'magic_results) '
-                        'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                        'magic_results, file_sha256) '
+                        'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
                         (item.row_type, item.origin, item.key, item.value, sql_date(item.last_modified),
                          item.interpretation, item.profile, item.source_path, item.seq,
                          state_to_int(item.state), item.state,
-                         item.file_exists, item.file_size, item.magic_results))
+                         item.file_exists, item.file_size, item.magic_results, item.file_sha256))
 
                 elif item.row_type.startswith('service worker'):
                     c.execute(

--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -3706,6 +3706,19 @@ class Chrome(WebBrowser):
                                 tl_item.data_summary = data_summary
                                 tl_item.http_headers_str = str(headers_dict) if headers_dict else ''
                                 tl_item.etag = etag_val
+                                # Same digest already computed for the Storage row above,
+                                # so the Timeline's Body SHA256 column covers every cache
+                                # row with a body rather than only the HTTP cache ones.
+                                #
+                                # Recorded unconditionally, unlike the HTTP cache:
+                                # CacheStorage holds the body the Cache API was handed,
+                                # already decoded, while keeping the original response
+                                # headers, so its content-encoding describes the wire form
+                                # and not these bytes. Measured across the test corpus: of
+                                # 3,230 entries declaring an encoding, no gzip one (1,688)
+                                # begins with the gzip magic and no brotli one (1,542)
+                                # decompresses; all hold readable content.
+                                tl_item.body_sha256 = body_sha
                                 tl_item.last_modified = last_mod_val
                                 tl_item.source_item = os.path.relpath(
                                     scf_path, self.profile_path)
@@ -3742,6 +3755,7 @@ class Chrome(WebBrowser):
 
         cache_items = profile.iterate_cache(url=None, omit_cached_data=False)
         source_item = os.path.relpath(os.path.join(path, dir_name), self.profile_path)
+        unhashed_bodies = 0
 
         try:
             for cache_item in cache_items:
@@ -3764,6 +3778,13 @@ class Chrome(WebBrowser):
                 parsed_item.stringify_http_headers()
                 parsed_item.etag = (cache_item.metadata.get_attribute("etag") or [""])[0]
                 parsed_item.last_modified = (cache_item.metadata.get_attribute("last-modified") or [""])[0]
+                # The body is already in memory (omit_cached_data=False), so this costs
+                # no extra reads.
+                parsed_item.hash_body(cache_item.was_decompressed)
+                if cache_item.data and parsed_item.body_sha256 is None:
+                    # Body present but left unhashed because it could not be decoded. An
+                    # empty hash cell otherwise reads as "no body", so count them.
+                    unhashed_bodies += 1
                 parsed_item.source_item = source_item
 
                 results.append(parsed_item)
@@ -3771,6 +3792,11 @@ class Chrome(WebBrowser):
         except Exception as e:
             log.error(f' - Exception parsing Cache items: {e})', exc_info=True)
             return None
+
+        if unhashed_bodies:
+            log.warning(f' - {unhashed_bodies} cached bodies were not hashed; their '
+                        f'content-encoding could not be decoded, so the bytes on disk '
+                        f'are not the resource')
 
         self.parsed_artifacts.extend(results)
         return unparsed.result(len(results))
@@ -4238,7 +4264,8 @@ class Chrome(WebBrowser):
             'source_path': node['source_path'],
             'file_exists': node.get('file_exists'),
             'file_size': node.get('file_size'),
-            'magic_results': node.get('magic_results')
+            'magic_results': node.get('magic_results'),
+            'file_sha256': node.get('file_sha256')
         }
 
         if node.get('modification_time'):
@@ -4250,13 +4277,21 @@ class Chrome(WebBrowser):
 
     @staticmethod
     def get_local_file_info(file_path):
-        file_size, magic_results = None, None
+        """Describe a File System API backing file: existence, size, type and SHA-256.
+
+        These are real files a site stored on disk, so the hash is what makes one
+        comparable to anything outside the profile (a known-file set, a copy recovered
+        elsewhere). Empty files are left unhashed: the digest of no bytes identifies
+        nothing, and a constant appearing throughout the output reads as a finding.
+        """
+        file_size, magic_results, file_sha256 = None, None, None
         exists = os.path.isfile(file_path)
 
         if exists:
             file_size = os.stat(file_path).st_size
 
         if file_size:
+            file_sha256 = utils.sha256_file(file_path)
             magic_candidates = puremagic.magic_file(file_path)
             if magic_candidates:
                 for magic_candidate in magic_candidates:
@@ -4266,7 +4301,7 @@ class Chrome(WebBrowser):
                     else:
                         magic_results = f'{magic_candidate.name} ({magic_candidate.confidence:.0%})'
 
-        return exists, file_size, magic_results
+        return exists, file_size, magic_results, file_sha256
 
     def get_file_system(self, path, dir_name):
 
@@ -4367,11 +4402,12 @@ class Chrome(WebBrowser):
                             if len(path_parts) >= 2:
                                 normalized_backing_file_path = os.path.join(
                                     path_nodes['0']['fs_path'], fs_type, path_parts[0], path_parts[1])
-                                file_exists, file_size, magic_results = self.get_local_file_info(
+                                file_exists, file_size, magic_results, file_sha256 = self.get_local_file_info(
                                            os.path.join(self.profile_path, normalized_backing_file_path))
                                 backing_file['file_exists'] = file_exists
                                 backing_file['file_size'] = file_size
                                 backing_file['magic_results'] = magic_results
+                                backing_file['file_sha256'] = file_sha256
 
                             else:
                                 normalized_backing_file_path = os.path.join(
@@ -4426,6 +4462,7 @@ class Chrome(WebBrowser):
                                     'file_exists': backing_file.get('file_exists'),
                                     'file_size': backing_file.get('file_size'),
                                     'magic_results': backing_file.get('magic_results'),
+                                    'file_sha256': backing_file.get('file_sha256'),
                                 })
 
                         result_count += 1
@@ -4462,7 +4499,7 @@ class Chrome(WebBrowser):
                             value=item.get('local_path'), seq=item['seq'], state=item['state'],
                             source_path=str(item['source_path']), last_modified=item.get('modification_time'),
                             file_exists=item.get('file_exists'), file_size=item.get('file_size'),
-                            magic_results=item.get('magic_results')
+                            magic_results=item.get('magic_results'), file_sha256=item.get('file_sha256')
                         ))
 
         self.parsed_storage.extend(result_list)

--- a/pyhindsight/browsers/webbrowser.py
+++ b/pyhindsight/browsers/webbrowser.py
@@ -803,6 +803,7 @@ class WebBrowser(object):
             self.etag = None
             self.last_modified = None
             self.locations_str = None
+            self.body_sha256 = None
 
         def create_data_summary(self):
             if not self.data:
@@ -812,6 +813,28 @@ class WebBrowser(object):
                 return f"{len(self.data)} bytes"
 
             return f"{(self.metadata.get_attribute('content-type') or ['not specified'])[0]} ({len(self.data)} bytes)"
+
+        def hash_body(self, was_decompressed=False):
+            """Hash the cached response body, unless those bytes are still encoded.
+
+            The digest is worth recording because it identifies the resource, so a cached
+            copy can be matched against a file recovered anywhere else. Chrome's HTTP
+            cache stores a body as it arrived and ccl decodes it per content-encoding, but
+            returns the compressed bytes when that fails. Hashing those would give the
+            digest of a gzip stream, indistinguishable in the output from a digest of the
+            resource and matching nothing, so no hash is recorded for them.
+            """
+            if not self.data:
+                return
+
+            declared_encoding = ''
+            if self.metadata:
+                declared_encoding = (
+                    self.metadata.get_attribute('content-encoding') or [''])[0].strip()
+            if declared_encoding and not was_decompressed:
+                return
+
+            self.body_sha256 = hashlib.sha256(self.data).hexdigest()
 
         def stringify_http_headers(self):
             headers = {}
@@ -1080,7 +1103,8 @@ class WebBrowser(object):
 
     class StorageItem(object):
         def __init__(self, item_type, profile, origin, key, value=None, seq=None, state=None, source_path=None,
-                     last_modified=None, interpretation=None, file_exists=None, file_size=None, magic_results=None):
+                     last_modified=None, interpretation=None, file_exists=None, file_size=None, magic_results=None,
+                     file_sha256=None):
             self.row_type = item_type
             self.profile = profile
             self.origin = origin
@@ -1094,6 +1118,7 @@ class WebBrowser(object):
             self.file_exists = file_exists
             self.file_size = file_size
             self.magic_results = magic_results
+            self.file_sha256 = file_sha256
 
         def __lt__(self, other):
             return self.origin < other.origin
@@ -1211,11 +1236,11 @@ class WebBrowser(object):
 
     class FileSystemItem(StorageItem):
         def __init__(self, profile, origin, key, value, seq, state, source_path, last_modified=None,
-                     file_exists=None, file_size=None, magic_results=None):
+                     file_exists=None, file_size=None, magic_results=None, file_sha256=None):
             super(WebBrowser.FileSystemItem, self).__init__(
                 'file system', profile=profile, origin=origin, key=key, value=value, seq=seq, state=state,
                 source_path=source_path, last_modified=last_modified, file_exists=file_exists,
-                file_size=file_size, magic_results=magic_results)
+                file_size=file_size, magic_results=magic_results, file_sha256=file_sha256)
             self.profile = profile
             self.origin = origin
             self.key = key
@@ -1227,6 +1252,7 @@ class WebBrowser(object):
             self.file_exists = file_exists
             self.file_size = file_size
             self.magic_results = magic_results
+            self.file_sha256 = file_sha256
 
     class ServiceWorkerUserDataItem(StorageItem):
         def __init__(self, profile, scope_url, registration_id, user_data_key,

--- a/pyhindsight/utils.py
+++ b/pyhindsight/utils.py
@@ -1,4 +1,5 @@
 import datetime
+import hashlib
 import json
 import logging
 import os
@@ -39,6 +40,24 @@ def text_factory(row_data):
         return row_data.decode('utf-8')
     except UnicodeDecodeError:
         return row_data
+
+
+def sha256_file(file_path, chunk_size=1024 * 1024):
+    """Return the SHA-256 of a file as hex, or None if it cannot be read.
+
+    Read in chunks so a large file does not have to fit in memory. A hash is
+    supplementary to the record it annotates, so an unreadable file returns None
+    rather than raising and costing the caller the whole artifact.
+    """
+    digest = hashlib.sha256()
+    try:
+        with open(file_path, 'rb') as f:
+            for chunk in iter(lambda: f.read(chunk_size), b''):
+                digest.update(chunk)
+    except OSError as e:
+        log.debug(f' - Could not hash {file_path}: {e}')
+        return None
+    return digest.hexdigest()
 
 
 def note_open_failure(browser, database_path, database_name, reason):

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -1,0 +1,346 @@
+"""SHA-256 over File System backing files and cached response bodies.
+
+Both are content Hindsight already reads and then describes only in ways that cannot be
+compared to anything: a size and a guessed type for a stored file, a size and a
+content-type for a cached body. A digest is what makes either of them matchable against
+a known-file set, a copy recovered elsewhere in the evidence, or the same resource in
+another profile.
+
+The cache half has a trap worth pinning. Chrome's HTTP cache stores a response body as it
+arrived on the wire, so ccl decompresses it per content-encoding, and when that fails it
+silently returns the compressed bytes instead. Hashing those would give the digest of a
+gzip stream, which in the output is indistinguishable from a digest of the resource and
+matches nothing, so the hash is withheld rather than qualified. An absent digest is a
+question; a wrong one that looks right is a wrong answer.
+
+CacheStorage is the opposite and is not covered here: it stores the already-decoded body
+while keeping the original response headers, so content-encoding and content-length there
+describe the wire form rather than the bytes on disk and cannot be used to answer this.
+Its rows are built in `Chrome.get_service_workers`, which these tests do not reach; that
+gap is what issue #313 (row-level output inspection) is for.
+"""
+
+import datetime
+import hashlib
+import io
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+
+import openpyxl
+
+from pyhindsight import utils
+from pyhindsight.analysis import AnalysisSession, HindsightEncoder
+from pyhindsight.browsers.chrome import Chrome
+from pyhindsight.browsers.webbrowser import WebBrowser
+
+UTC = datetime.timezone.utc
+
+# A PNG signature followed by filler. Real magic bytes so puremagic identifies the file
+# the way it would in a profile, rather than the hash path being exercised on content
+# the type detection never sees.
+PNG_BYTES = b'\x89PNG\r\n\x1a\n' + b'hindsight test file' * 8
+PNG_SHA256 = hashlib.sha256(PNG_BYTES).hexdigest()
+
+
+class FakeMetadata:
+    """The two CachedMetadata members the cache parser touches."""
+
+    def __init__(self, **attributes):
+        self.attributes = attributes
+        self.http_header_attributes = list(attributes.items())
+
+    def get_attribute(self, name):
+        value = self.attributes.get(name)
+        return [value] if value is not None else []
+
+
+def cache_item(data, was_decompressed=False, **attributes):
+    item = WebBrowser.CacheItem(
+        profile='p', url='https://example.test/logo.png', title=None,
+        request_time=datetime.datetime(2024, 6, 1, tzinfo=UTC),
+        locations='{}', key='https://example.test/logo.png',
+        metadata=FakeMetadata(**attributes), data=data)
+    item.hash_body(was_decompressed)
+    return item
+
+
+class TestSha256File(unittest.TestCase):
+
+    def setUp(self):
+        self.directory = tempfile.mkdtemp()
+        self.path = os.path.join(self.directory, 'backing_file')
+        with open(self.path, 'wb') as f:
+            f.write(PNG_BYTES)
+
+    def tearDown(self):
+        if os.path.isfile(self.path):
+            os.remove(self.path)
+        os.rmdir(self.directory)
+
+    def test_it_matches_the_digest_of_the_whole_file(self):
+        self.assertEqual(PNG_SHA256, utils.sha256_file(self.path))
+
+    def test_a_file_spanning_many_chunks_hashes_the_same(self):
+        # The chunked read must reassemble to one digest; a per-chunk or truncated
+        # digest would still look like a plausible hash in the output.
+        self.assertEqual(PNG_SHA256, utils.sha256_file(self.path, chunk_size=7))
+
+    def test_a_missing_file_returns_none(self):
+        self.assertIsNone(utils.sha256_file(os.path.join(self.directory, 'absent')))
+
+    def test_an_unreadable_path_returns_none_rather_than_raising(self):
+        # A hash annotates a record; failing to take one must not cost the caller the
+        # artifact those records belong to.
+        self.assertIsNone(utils.sha256_file(self.directory))
+
+
+class TestGetLocalFileInfo(unittest.TestCase):
+    """File System API backing files: the hash rides alongside size and type."""
+
+    def setUp(self):
+        self.directory = tempfile.mkdtemp()
+
+    def tearDown(self):
+        for name in os.listdir(self.directory):
+            os.remove(os.path.join(self.directory, name))
+        os.rmdir(self.directory)
+
+    def _write(self, name, content):
+        path = os.path.join(self.directory, name)
+        with open(path, 'wb') as f:
+            f.write(content)
+        return path
+
+    def test_a_stored_file_is_hashed(self):
+        exists, size, magic_results, sha256 = Chrome.get_local_file_info(
+            self._write('stored', PNG_BYTES))
+        self.assertTrue(exists)
+        self.assertEqual(len(PNG_BYTES), size)
+        self.assertEqual(PNG_SHA256, sha256)
+        self.assertIsNotNone(magic_results)
+
+    def test_an_empty_file_is_not_given_the_digest_of_no_bytes(self):
+        # e3b0c442... would otherwise appear against every empty file and read as a
+        # group of identical files rather than as an absence of content.
+        exists, size, _, sha256 = Chrome.get_local_file_info(self._write('empty', b''))
+        self.assertTrue(exists)
+        self.assertEqual(0, size)
+        self.assertIsNone(sha256)
+
+    def test_a_missing_file_reports_no_hash(self):
+        exists, size, magic_results, sha256 = Chrome.get_local_file_info(
+            os.path.join(self.directory, 'absent'))
+        self.assertFalse(exists)
+        self.assertIsNone(size)
+        self.assertIsNone(magic_results)
+        self.assertIsNone(sha256)
+
+
+class TestCacheBodyHash(unittest.TestCase):
+
+    def test_a_cached_body_is_hashed(self):
+        self.assertEqual(PNG_SHA256, cache_item(PNG_BYTES).body_sha256)
+
+    def test_an_evicted_entry_has_no_hash(self):
+        # Its metadata survives without its body; a digest here would describe nothing.
+        self.assertIsNone(cache_item(None).body_sha256)
+
+    def test_a_decompressed_body_is_hashed(self):
+        # ccl decoded it, so the bytes in hand are the resource.
+        item = cache_item(PNG_BYTES, was_decompressed=True, **{'content-encoding': 'gzip'})
+        self.assertEqual(PNG_SHA256, item.body_sha256)
+
+    def test_a_body_that_failed_to_decompress_is_not_hashed(self):
+        # ccl returns the compressed bytes on a decompression failure. Their digest would
+        # sit in the same column as every other one, look equally authoritative, and match
+        # nothing, so no digest is recorded at all.
+        item = cache_item(PNG_BYTES, was_decompressed=False,
+                          **{'content-encoding': 'gzip'})
+        self.assertIsNone(item.body_sha256)
+
+    def test_the_withheld_hash_is_the_only_thing_withheld(self):
+        # The row itself still carries the entry: the URL, the timestamp and the size are
+        # unaffected by whether the body could be decoded.
+        item = cache_item(PNG_BYTES, was_decompressed=False,
+                          **{'content-encoding': 'gzip', 'content-type': 'image/png'})
+        self.assertEqual('https://example.test/logo.png', item.url)
+        self.assertEqual(f'image/png ({len(PNG_BYTES)} bytes)', item.create_data_summary())
+
+    def test_an_entry_without_metadata_still_hashes(self):
+        # No headers means no declared encoding to disqualify the bytes.
+        item = WebBrowser.CacheItem(
+            profile='p', url='https://example.test/', title=None,
+            request_time=None, locations='{}', key='k', metadata=None, data=PNG_BYTES)
+        item.hash_body()
+        self.assertEqual(PNG_SHA256, item.body_sha256)
+
+
+def _file_system_item(sha256):
+    return WebBrowser.FileSystemItem(
+        profile='p', origin='https://example.test', key='docs/report.pdf',
+        value='File System/000/p/00/00000000', seq=1, state='Live',
+        source_path='File System/Origins', last_modified=None,
+        file_exists=True, file_size=len(PNG_BYTES), magic_results='image/png (100%)',
+        file_sha256=sha256)
+
+
+def _cache_row(row_type='cache', was_decompressed=True, **attributes):
+    item = cache_item(PNG_BYTES, was_decompressed=was_decompressed,
+                      **(attributes or {'content-encoding': 'gzip'}))
+    item.row_type = row_type
+    item.data_summary = item.create_data_summary()
+    item.interpretation = None
+    item.source_item = 'Cache'
+    item.etag = ''
+    item.last_modified = ''
+    item.http_headers_str = '{}'
+    return item
+
+
+class TestHashesReachTheOutput(unittest.TestCase):
+    """A hash computed and then dropped before the report is worse than none at all."""
+
+    def setUp(self):
+        self.session = AnalysisSession.__new__(AnalysisSession)
+        self.session.parsed_artifacts = [_cache_row()]
+        self.session.parsed_storage = [_file_system_item(PNG_SHA256)]
+        self.session.parsed_extension_data = []
+        self.session.parsed_sync_data = []
+        self.session.preferences = []
+        self.session.installed_extensions = None
+        self.session.timezone = UTC
+        self.directory = tempfile.mkdtemp()
+
+    def tearDown(self):
+        for name in os.listdir(self.directory):
+            os.remove(os.path.join(self.directory, name))
+        os.rmdir(self.directory)
+
+    def test_sqlite_carries_both_hashes(self):
+        path = os.path.join(self.directory, 'report.sqlite')
+        self.session.generate_sqlite(path)
+        con = sqlite3.connect(path)
+        try:
+            self.assertEqual(
+                (PNG_SHA256,),
+                con.execute('SELECT body_sha256 FROM timeline').fetchone())
+            self.assertEqual(
+                (PNG_SHA256,),
+                con.execute('SELECT file_sha256 FROM storage').fetchone())
+        finally:
+            con.close()
+
+    def test_jsonl_carries_both_hashes(self):
+        path = os.path.join(self.directory, 'report.jsonl')
+        self.session.generate_jsonl(path)
+        with open(path, encoding='utf-8') as f:
+            records = [json.loads(line) for line in f if line.strip()]
+
+        by_type = {record['data_type']: record for record in records}
+        self.assertEqual(PNG_SHA256, by_type['chrome:cache:entry']['body_sha256'])
+        self.assertEqual(PNG_SHA256, by_type['chrome:file_system:entry']['file_sha256'])
+
+    def test_an_undecodable_body_reaches_the_output_without_a_hash(self):
+        # The field is simply absent rather than present and wrong.
+        self.session.parsed_artifacts = [
+            _cache_row(was_decompressed=False, **{'content-encoding': 'gzip'})]
+        path = os.path.join(self.directory, 'encoded.jsonl')
+        self.session.generate_jsonl(path)
+        with open(path, encoding='utf-8') as f:
+            records = [json.loads(line) for line in f if line.strip()]
+
+        cache_records = [r for r in records if r['data_type'] == 'chrome:cache:entry']
+        self.assertEqual(1, len(cache_records))
+        self.assertNotIn('body_sha256', cache_records[0])
+
+    def test_the_encoder_keeps_the_hash_when_it_drops_the_body(self):
+        # The encoder pops `data` so the report does not carry the bytes; the digest is
+        # what survives to identify them, so it must not be dropped with them.
+        encoded = json.loads(json.dumps(_cache_row(), cls=HindsightEncoder))
+        self.assertNotIn('data', encoded)
+        self.assertEqual(PNG_SHA256, encoded['body_sha256'])
+
+    def test_service_worker_cache_rows_are_carried_too(self):
+        # CacheStorage entries reach the Timeline as their own row_type from a second
+        # producer, and were 89% of the cache rows in the corpus root this was checked
+        # against. A hash on only the HTTP cache ones would have looked like a working
+        # feature while missing most of the output.
+        self.session.parsed_artifacts = [_cache_row('cache (service worker)')]
+        path = os.path.join(self.directory, 'sw.sqlite')
+        self.session.generate_sqlite(path)
+        con = sqlite3.connect(path)
+        try:
+            self.assertEqual(
+                (PNG_SHA256,),
+                con.execute('SELECT body_sha256 FROM timeline').fetchone())
+        finally:
+            con.close()
+
+
+class TestXlsxColumns(unittest.TestCase):
+    """The hashes must land under their own headers.
+
+    Both sheets grew a column, which moved merge ranges and the autofilter. An
+    off-by-one here writes a digest under a neighbouring header, which is worse than
+    omitting it: the value looks authoritative and describes the wrong thing.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        session = AnalysisSession.__new__(AnalysisSession)
+        session.parsed_artifacts = [_cache_row()]
+        session.parsed_storage = [_file_system_item(PNG_SHA256)]
+        session.parsed_extension_data = []
+        session.parsed_sync_data = []
+        session.preferences = []
+        session.installed_extensions = None
+        session.plugin_results = {}
+        session.timezone = UTC
+        session.artifact_filter = None
+
+        buffer = io.BytesIO()
+        session.generate_excel(buffer)
+        buffer.seek(0)
+        cls.workbook = openpyxl.load_workbook(buffer)
+
+    def _column_under(self, sheet_name, header):
+        sheet = self.workbook[sheet_name]
+        for cell in sheet[2]:  # headers are on row 2; row 1 is the title bar
+            if cell.value == header:
+                return cell.column
+        self.fail(f'no {header!r} header on the {sheet_name} sheet')
+
+    def _value_under(self, sheet_name, header):
+        sheet = self.workbook[sheet_name]
+        return sheet.cell(row=3, column=self._column_under(sheet_name, header)).value
+
+    def test_the_cache_body_hash_is_under_its_header(self):
+        self.assertEqual(PNG_SHA256, self._value_under('Timeline', 'Body SHA256'))
+
+    def test_the_file_hash_is_under_its_header(self):
+        self.assertEqual(PNG_SHA256, self._value_under('Storage', 'File SHA256'))
+
+    def test_the_neighbouring_columns_did_not_shift(self):
+        # The columns the new ones were appended after must still hold their own values.
+        self.assertEqual('{}', self._value_under('Timeline', 'All HTTP Headers'))
+        self.assertEqual('image/png (100%)',
+                         self._value_under('Storage', 'File Type (Confidence %)'))
+
+    def test_every_column_is_inside_the_autofilter(self):
+        # The Storage filter stopped a column short before this change, so the last
+        # column could not be filtered on at all.
+        for sheet_name, header in (('Timeline', 'Body SHA256'),
+                                   ('Storage', 'File SHA256')):
+            with self.subTest(sheet=sheet_name):
+                sheet = self.workbook[sheet_name]
+                last_filtered = openpyxl.utils.range_boundaries(
+                    sheet.auto_filter.ref)[2]
+                self.assertGreaterEqual(last_filtered,
+                                        self._column_under(sheet_name, header))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Records a SHA-256 for each cached response body and each File System API backing file, so an artifact recovered from a profile can be matched against a copy found anywhere else.

A cache body is only hashed when the bytes on disk are actually the resource. ccl returns the still-compressed bytes when it cannot decode a content-encoding, and hashing those gives the digest of a gzip stream, which matches nothing and looks identical in the output to a digest of the real thing. Empty files are skipped for the same reason: the digest of no bytes identifies nothing, and a constant repeated down a column reads as a finding.

Output gains Body SHA256 on the Timeline sheet, File SHA256 on the Storage sheet, and the matching sqlite columns. The Storage autofilter stopped a column short of File Type, so the last column could not be filtered on at all; it now covers every column.

Adds tests/test_hashing.py, covering that the digests land under the right headers, that the neighbouring columns did not shift, and that every column falls inside the autofilter. Full suite passes including the corpus parse tests.