### PR TITLE
Separate IndexedDB database from object store, and keep the value structured

### DIFF
--- a/pyhindsight/analysis.py
+++ b/pyhindsight/analysis.py
@@ -441,6 +441,14 @@ class HindsightEncoder(json.JSONEncoder):
         if isinstance(obj, Chrome.IndexedDBItem):
             item = HindsightEncoder.base_encoder(obj)
 
+            # value is a property, so base_encoder's __dict__ walk never sees it, and the
+            # private fields it does see must not reach the output: _value_obj is an
+            # arbitrary deserialized structure json cannot be relied on to render. Same
+            # pattern as the cache body a few branches up.
+            item.pop('_value_obj', None)
+            item.pop('_value_str', None)
+            item['value'] = obj.value
+
             item['timestamp_desc'] = 'Not a time'
             item['data_type'] = 'chrome:indexeddb:entry'
             item['source_long'] = 'Chrome IndexedDB'
@@ -450,6 +458,7 @@ class HindsightEncoder(json.JSONEncoder):
 
             item['message'] = (
                 f'database: {item.get("database", "")} '
+                f'object store: {item.get("object_store", "")} '
                 f'key: {item.get("key", "")} '
                 f'value: {item.get("value", "")}'
             )
@@ -1951,8 +1960,8 @@ class AnalysisSession(object):
         used_sheet_names.add('storage')
         # Title bar
         s.merge_range('A1:G1', f'Hindsight Internet History Forensics (v{__version__}) - Storage', title_header_format)
-        s.merge_range('H1:K1', 'Backing Database Specific', center_header_format)
-        s.merge_range('L1:O1', 'FileSystem Specific', center_header_format)
+        s.merge_range('H1:L1', 'Backing Database Specific', center_header_format)
+        s.merge_range('M1:P1', 'FileSystem Specific', center_header_format)
 
         # Write column headers
         s.write(1, 0, 'Type', header_format)
@@ -1964,12 +1973,13 @@ class AnalysisSession(object):
         s.write(1, 6, 'Profile', header_format)
         s.write(1, 7, 'Source Item', header_format)
         s.write(1, 8, 'Database', header_format)
-        s.write(1, 9, 'Sequence', header_format)
-        s.write(1, 10, 'State', header_format)
-        s.write(1, 11, 'File Exists?', header_format)
-        s.write(1, 12, 'File Size (bytes)', header_format)
-        s.write(1, 13, 'File Type (Confidence %)', header_format)
-        s.write(1, 14, 'File SHA256', header_format)
+        s.write(1, 9, 'Object Store', header_format)
+        s.write(1, 10, 'Sequence', header_format)
+        s.write(1, 11, 'State', header_format)
+        s.write(1, 12, 'File Exists?', header_format)
+        s.write(1, 13, 'File Size (bytes)', header_format)
+        s.write(1, 14, 'File Type (Confidence %)', header_format)
+        s.write(1, 15, 'File SHA256', header_format)
 
         # Set column widths
         s.set_column('A:A', 16)  # Type
@@ -1981,12 +1991,13 @@ class AnalysisSession(object):
         s.set_column('G:G', 50)  # Profile
         s.set_column('H:H', 50)  # Source Path
         s.set_column('I:I', 16)  # Database
-        s.set_column('J:J', 8)   # Seq
-        s.set_column('K:K', 8)   # State
-        s.set_column('L:L', 8)   # Exists
-        s.set_column('M:M', 16)  # Size
-        s.set_column('N:N', 25)  # Type
-        s.set_column('O:O', 66)  # SHA256 (64 hex characters)
+        s.set_column('J:J', 24)  # Object Store
+        s.set_column('K:K', 8)   # Seq
+        s.set_column('L:L', 8)   # State
+        s.set_column('M:M', 8)   # Exists
+        s.set_column('N:N', 16)  # Size
+        s.set_column('O:O', 25)  # Type
+        s.set_column('P:P', 66)  # SHA256 (64 hex characters)
 
         # Start at the row after the headers, and begin writing out the items in parsed_artifacts
         row_number = 2
@@ -2004,12 +2015,12 @@ class AnalysisSession(object):
                     s.write(row_number, 5, item.interpretation, black_value_format)
                     s.write(row_number, 6, item.profile, black_value_format)
                     s.write(row_number, 7, source_item(item.source_path, item.profile), black_value_format)
-                    s.write_number(row_number, 9, item.seq, black_value_format)
-                    s.write_string(row_number, 10, item.state, black_value_format)
-                    s.write(row_number, 11, item.file_exists, black_value_format)
-                    s.write(row_number, 12, item.file_size, black_value_format)
-                    s.write(row_number, 13, item.magic_results, black_value_format)
-                    s.write(row_number, 14, item.file_sha256, black_value_format)
+                    s.write_number(row_number, 10, item.seq, black_value_format)
+                    s.write_string(row_number, 11, item.state, black_value_format)
+                    s.write(row_number, 12, item.file_exists, black_value_format)
+                    s.write(row_number, 13, item.file_size, black_value_format)
+                    s.write(row_number, 14, item.magic_results, black_value_format)
+                    s.write(row_number, 15, item.file_sha256, black_value_format)
 
                 elif item.row_type.startswith(("local storage", "session storage")):
                     s.write_string(row_number, 0, item.row_type, black_type_format)
@@ -2020,8 +2031,8 @@ class AnalysisSession(object):
                     s.write(row_number, 5, item.interpretation, black_value_format)
                     s.write(row_number, 6, item.profile, black_value_format)
                     s.write(row_number, 7, source_item(item.source_path, item.profile), black_value_format)
-                    s.write_number(row_number, 9, item.seq, black_value_format)
-                    s.write_string(row_number, 10, item.state, black_value_format)
+                    s.write_number(row_number, 10, item.seq, black_value_format)
+                    s.write_string(row_number, 11, item.state, black_value_format)
 
                 elif item.row_type.startswith("indexeddb"):
                     s.write_string(row_number, 0, item.row_type, black_type_format)
@@ -2032,8 +2043,9 @@ class AnalysisSession(object):
                     s.write(row_number, 6, item.profile, black_value_format)
                     s.write(row_number, 7, source_item(item.source_path, item.profile), black_value_format)
                     s.write(row_number, 8, item.database, black_value_format)
-                    s.write_number(row_number, 9, item.seq, black_value_format)
-                    s.write_string(row_number, 10, item.state, black_value_format)
+                    s.write(row_number, 9, item.object_store, black_value_format)
+                    s.write_number(row_number, 10, item.seq, black_value_format)
+                    s.write_string(row_number, 11, item.state, black_value_format)
 
                 else:
                     s.write_string(row_number, 0, item.row_type, black_type_format)
@@ -2044,8 +2056,8 @@ class AnalysisSession(object):
                     s.write(row_number, 6, item.profile, black_value_format)
                     s.write(row_number, 7, source_item(item.source_path, item.profile), black_value_format)
                     # s.write(row_number, 8, item.database, black_value_format)
-                    s.write_number(row_number, 9, item.seq, black_value_format)
-                    s.write_string(row_number, 10, item.state, black_value_format)
+                    s.write_number(row_number, 10, item.seq, black_value_format)
+                    s.write_string(row_number, 11, item.state, black_value_format)
 
             except Exception as e:
                 log.error(f'Failed to write row to XLSX: {e}')
@@ -2056,7 +2068,7 @@ class AnalysisSession(object):
         s.freeze_panes(2, 0)  # Freeze top row
         # 14, not 12: the range stopped short of File Type before the SHA256 column
         # was added, leaving the last column(s) outside the filter.
-        s.autofilter(1, 0, row_number, 14)  # Add autofilter
+        s.autofilter(1, 0, row_number, 15)  # Add autofilter
 
         #########################################
         # Service Workers worksheet
@@ -3125,7 +3137,8 @@ class AnalysisSession(object):
             c.execute(
                 'CREATE TABLE storage(type TEXT, origin TEXT, key TEXT, value TEXT, '
                 'modification_time TEXT, interpretation TEXT, profile TEXT, source_path TEXT, '
-                'database TEXT, seq INT, state INT, state_friendly TEXT, file_exists BOOL, file_size INT, '
+                'database TEXT, object_store TEXT, key_type TEXT, key_raw TEXT, '
+                'seq INT, state INT, state_friendly TEXT, file_exists BOOL, file_size INT, '
                 'magic_results TEXT, file_sha256 TEXT)')
 
             c.execute(
@@ -3322,10 +3335,12 @@ class AnalysisSession(object):
                 elif item.row_type.startswith('indexed'):
                     c.execute(
                         'INSERT INTO storage (type, origin, key, value, '
-                        'interpretation, profile, source_path, seq, state, state_friendly, database) '
-                        'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                        'interpretation, profile, source_path, seq, state, state_friendly, database, '
+                        'object_store, key_type, key_raw) '
+                        'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
                         (item.row_type, item.origin, item.key, item.value, item.interpretation, item.profile,
-                         item.source_path, item.seq, state_to_int(item.state), item.state, item.database))
+                         item.source_path, item.seq, state_to_int(item.state), item.state, item.database,
+                         item.object_store, item.key_type, item.key_raw))
 
                 else:
                     # Previously fell through with no branch and no message, which is

--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -2079,10 +2079,21 @@ class Chrome(WebBrowser):
 
                                 record_value = self.resolve_indexeddb_blob_refs(record, origin)
 
+                                # Read defensively: the enclosing except aborts the rest
+                                # of this object store, so a key shaped unexpectedly must
+                                # cost its own record's metadata, not every record after
+                                # it.
+                                idb_key = getattr(record, 'key', None)
+                                key_type = getattr(getattr(idb_key, 'key_type', None), 'name', None)
+                                raw_key = getattr(idb_key, 'raw_key', None)
+
                                 results.append(Chrome.IndexedDBItem(
-                                    self.profile_path, origin, str(record.key.value), str(record_value),
-                                    int(record.ldb_seq_no), database=f"{record.database_name}.{obj_store_name}",
-                                    state=record_state, source_path=record_source_path))
+                                    self.profile_path, origin, str(getattr(idb_key, 'value', None)), None,
+                                    int(record.ldb_seq_no), database=record.database_name,
+                                    state=record_state, source_path=record_source_path,
+                                    object_store=obj_store_name, key_type=key_type,
+                                    key_raw=raw_key.hex() if isinstance(raw_key, (bytes, bytearray)) else None,
+                                    value_obj=record_value))
                         except FileNotFoundError as e:
                             unparsed.source(database, f'file not found ({e})')
 

--- a/pyhindsight/browsers/firefox.py
+++ b/pyhindsight/browsers/firefox.py
@@ -2702,13 +2702,16 @@ class Firefox(WebBrowser):
 
                         key_str = self._decode_idb_key(key_blob) if key_blob else ''
 
-                        value_str = ''
+                        # The deserialized value is kept and rendered at output time, so
+                        # plugins get the structure rather than a re-parse of its text.
+                        # value_str is only set when there is no object to keep.
+                        value_str = None
+                        value_obj = Firefox.IndexedDBItem._NO_VALUE_OBJ
                         if data_blob:
                             try:
                                 decompressed = self._snappy_decompress(bytes(data_blob))
                                 reader = Firefox._StructuredCloneReader(self, decompressed)
                                 value_obj = reader.read()
-                                value_str = self._stringify_idb_value(value_obj)
                             except Exception as e:
                                 decode_failures += 1
                                 unparsed.record(f'{db_filename}:{key_str}',
@@ -2724,8 +2727,10 @@ class Firefox(WebBrowser):
                             value=value_str,
                             seq=seq,
                             state='Live',
-                            database=f'{db_name}.{store_name}',
+                            database=db_name,
+                            object_store=store_name,
                             source_path=source_path,
+                            value_obj=value_obj,
                         )
                         results.append(item)
                         got_any = True
@@ -3130,4 +3135,9 @@ class Firefox(WebBrowser):
         pass
 
     class IndexedDBItem(WebBrowser.IndexedDBItem):
-        pass
+        @staticmethod
+        def _render_value(value_obj):
+            # Firefox has always written its IndexedDB values as (truncated) JSON, where
+            # Chrome writes Python's repr. Rendering per browser keeps both outputs
+            # exactly as they were; unifying them is a separate decision.
+            return Firefox._stringify_idb_value(value_obj)

--- a/pyhindsight/browsers/webbrowser.py
+++ b/pyhindsight/browsers/webbrowser.py
@@ -1211,28 +1211,112 @@ class WebBrowser(object):
             self.source_path = source_path
 
     class IndexedDBItem(StorageItem):
-        def __init__(self, profile, origin, key, value, seq, state, database, source_path):
+        # Distinguishes "the parser supplied no value object" from "it supplied None".
+        # Both render blank; the difference is only visible to callers via has_value_obj.
+        _NO_VALUE_OBJ = object()
+
+        # Class-level defaults so `value` still resolves on a record built without
+        # __init__. The JSONL encoder must never raise: one exception there aborts the
+        # whole file rather than the single record that was odd.
+        _value_str = None
+        _value_obj = _NO_VALUE_OBJ
+
+        def __init__(self, profile, origin, key, value, seq, state, database, source_path,
+                     object_store=None, key_type=None, key_raw=None, value_obj=_NO_VALUE_OBJ):
             """
 
             :param profile: The path to the browser profile this item is part of.
             :param origin: The web origin this IndexedDBItem item belongs to.
-            :param key: The key of the IndexedDBItem item.
-            :param value: The value of the IndexedDBItem item.
+            :param key: The key of the IndexedDBItem item, rendered as a string.
+            :param value: A pre-rendered string form of the value. Parsers normally leave
+            this None and pass value_obj instead, so the value is rendered on demand; a
+            string belongs here only when there is no object to keep (e.g. the record
+            failed to deserialize).
             :param seq: The sequence number.
-            :param database: The database within the IndexedDB file the record is part of.
+            :param state: The state of the record (Live or Deleted).
+            :param database: The name of the IndexedDB database the record is part of.
+            The object store is a separate field: the two used to be joined with a '.',
+            which cannot be split back apart when a database name contains one.
             :param source_path: The path to the source of the record.
+            :param object_store: The name of the object store within `database`.
+            :param key_type: The IndexedDB type of the key ('String', 'Date', 'Array'...),
+            where the parser knows it.
+            :param key_raw: Hex of the key's raw bytes, where the parser has them. Hex and
+            not bytes because the JSONL encoder renders bytes as UTF-8 with replacement
+            characters, which would corrupt a binary key beyond recovery.
+            :param value_obj: The deserialized value. Preferred over a rendered string so
+            plugins receive the real structure rather than a re-parse of its repr. Holding
+            both forms roughly doubles IndexedDB memory, so pass one or the other.
             """
+            # Both must exist before super().__init__ assigns self.value, which now goes
+            # through the property setter below.
+            self._value_str = None
+            self._value_obj = value_obj
             super(WebBrowser.IndexedDBItem, self).__init__(
                 'indexeddb', profile=profile, origin=origin, key=key, value=value, seq=seq, state=state,
                 source_path=source_path)
             self.profile = profile
             self.origin = origin
             self.key = key
-            self.value = value
             self.seq = seq
             self.state = state
             self.database = database
+            self.object_store = object_store
+            self.key_type = key_type
+            self.key_raw = key_raw
             self.source_path = source_path
+
+        @property
+        def value(self):
+            """The value, rendered as a string.
+
+            Empty when no value was recovered. Otherwise rendered on demand so the
+            deserialized object is the only copy held. Keeping
+            the string alongside it costs roughly twice the memory of the object alone
+            (measured on a 4,164-record profile: 21 MB of strings, 28 MB of objects,
+            49 MB for both). Nothing reads this more than once per run -- each output
+            writer touches a row once, and no plugin reads .value on an IndexedDB row --
+            so not caching the rendering costs nothing.
+            """
+            if self._value_str is not None:
+                return self._value_str
+            if self._value_obj is self._NO_VALUE_OBJ or self._value_obj is None:
+                # Nothing was recovered, so the cell stays empty. ccl returns None both
+                # for a record whose LevelDB entry carries no value bytes -- what a
+                # deletion tombstone looks like, and the common case by far -- and for a
+                # serialized JS null, and the two cannot be told apart from here.
+                # Rendering Python's None put the literal string 'None' in the Value
+                # column, which reads as recovered data and is indistinguishable from a
+                # record whose value really is the string "None".
+                return ''
+            return self._render_value(self._value_obj)
+
+        @value.setter
+        def value(self, new_value):
+            self._value_str = new_value
+
+        @property
+        def has_value_obj(self):
+            """Whether the parser supplied a value object at all.
+
+            False means the parser had nothing to give (no data blob, or a decode that
+            failed). True with `value_obj` of None means the reader returned None, which
+            is a deletion tombstone or a stored JS null -- it cannot distinguish those.
+            Both render blank."""
+            return self._value_obj is not self._NO_VALUE_OBJ
+
+        @property
+        def value_obj(self):
+            """The deserialized value, for callers that need the structure rather than a
+            rendering of it. None when the parser only had a string to give -- check
+            `has_value_obj` to tell that apart from a stored null."""
+            return None if self._value_obj is self._NO_VALUE_OBJ else self._value_obj
+
+        @staticmethod
+        def _render_value(value_obj):
+            """Render a deserialized value for output. Overridden per browser so each one
+            keeps the rendering its output has always used."""
+            return str(value_obj)
 
     class FileSystemItem(StorageItem):
         def __init__(self, profile, origin, key, value, seq, state, source_path, last_modified=None,


### PR DESCRIPTION
Stacked on #316, because the Storage sheet column numbers here are computed on top of the File SHA256 column that PR adds. Review that one first.

The database and object store names were joined into one field as f"{database_name}.{obj_store_name}", which cannot reliably be split back apart. Not hypothetical: bf4sa_2025_bob-1 has 19 rows whose database name is Bitwarden's storage.bw.offline. They are separate fields now, and the key's IndexedDB type and raw bytes are recorded too, since str() of a number and of a numeric string look identical and a binary key had nowhere to go.

The value was stringified at parse time, so the structure a page stored was gone before anything could read it. The record now holds the deserialized object and renders the string on demand. Keeping both roughly doubles IndexedDB memory, measured on one profile at 21 MB of strings against 28 MB of objects and 49 MB for the pair, so only the object is kept. Nothing reads a rendered value more than once per run.

A record with no value used to render the string None. ccl returns None both for an entry carrying no value bytes, which is what a deletion tombstone looks like, and for a serialized JS null; the literal None read as recovered data and could not be told apart from a value that really was the string "None". Those cells are blank now.

Rendering is a per-browser override, so Chrome keeps its repr and Firefox its truncated JSON, and no existing output moved. New output is an Object Store column on the Storage sheet, plus object_store, key_type and key_raw in the sqlite storage table and JSONL records. key_raw is hex because the JSONL encoder renders bytes as UTF-8 with replacement, which would corrupt a binary key.

Checked against bf4sa_2025_bob-1 and its 35,235 IndexedDB rows: no row still carries a glued database name, every row carries a deserialized value, and no rendering differs from the old str() form. All six corpus baselines are unchanged. The blank-value fix was verified against cellebrite.ctf_2021, where all 238 deleted rows now render blank and no row contains the literal string None.