### PR TITLE
Run the timestamp decoder over storage rows, as it always claimed to

### DIFF
--- a/pyhindsight/plugins/generic_timestamps.py
+++ b/pyhindsight/plugins/generic_timestamps.py
@@ -14,7 +14,7 @@ artifactTypes = ("cookie (created)", "cookie (accessed)", "local storage", "inde
 remoteLookups = 0
 browser = "Chrome"
 browserVersion = 1
-version = "20240428"
+version = "20260905"
 parsedItems = 0
 
 
@@ -29,17 +29,41 @@ def plugin(analysis_session=None):
     global parsedItems
     parsedItems = 0
 
+    def decode(item, value):
+        """Set an interpretation if the value looks like a timestamp. Returns 1 if it did."""
+        m = re.search(timestamp_re, value)
+        if m:
+            item.interpretation = friendly_date(int(m.group(0))) + ' [potential timestamp]'
+            return 1
+        ls_m = re.search(ls_timestamp_re, value)
+        if ls_m:
+            item.interpretation = friendly_date(int(ls_m.group(1))) + ' [potential timestamp]'
+            return 1
+        return 0
+
     for item in analysis_session.parsed_artifacts:
         if item.row_type.startswith(artifactTypes):
             if item.interpretation is None:
-                m = re.search(timestamp_re, item.value)
-                ls_m = re.search(ls_timestamp_re, item.value)
-                if m:
-                    item.interpretation = friendly_date(int(m.group(0))) + ' [potential timestamp]'
-                    parsedItems += 1
-                elif ls_m:
-                    item.interpretation = friendly_date(int(ls_m.group(1))) + ' [potential timestamp]'
-                    parsedItems += 1
+                parsedItems += decode(item, item.value)
+
+    # 'local storage' and 'indexeddb' rows live in parsed_storage, never in
+    # parsed_artifacts, so naming them in artifactTypes did nothing on its own: this
+    # plugin had only ever seen cookies, and ls_timestamp_re -- written for Local
+    # Storage -- had never once run against a Local Storage value.
+    for item in analysis_session.parsed_storage:
+        if not item.row_type.startswith(artifactTypes):
+            continue
+        if item.interpretation is not None:
+            continue
+
+        # Read once: an IndexedDB value is rendered from its deserialized object on
+        # access, so repeating item.value repeats the rendering.
+        value = item.value
+        if not isinstance(value, str):
+            # Deleted records carry None in place of a value.
+            continue
+
+        parsedItems += decode(item, value)
 
     # Description of what the plugin did
     return "{} timestamps parsed".format(parsedItems)


### PR DESCRIPTION
Stacked on #317 because the comment about reading the value into a local only makes sense once an IndexedDB value renders on access. It applies cleanly to main if you would rather it went first.

artifactTypes has listed "local storage" and "indexeddb" since the plugin was written, but both live in parsed_storage and the plugin only ever walked parsed_artifacts. Neither had ever reached it, so in practice it saw cookies and nothing else, and ls_timestamp_re, written for Local Storage values, had never once run against one.

Adds the parsed_storage pass. Rows whose value is None are skipped, since deleted records carry nothing to match against.

On one test profile this goes from no results at all to 28,137 interpretations, 27,861 of them IndexedDB. I checked these are not noise by comparing against a stricter field-adjacent pattern: it matched 27,896, and there were no rows the loose pattern claimed that the strict one did not, so these are real "timestamp": <digits> fields. Worth knowing it now fills Interpretation on roughly 79% of IndexedDB rows.