### PR TITLE
Keep cache entries that have no metadata, untimed

### DIFF
--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -3767,28 +3767,40 @@ class Chrome(WebBrowser):
         cache_items = profile.iterate_cache(url=None, omit_cached_data=False)
         source_item = os.path.relpath(os.path.join(path, dir_name), self.profile_path)
         unhashed_bodies = 0
+        untimed_entries = 0
 
         try:
             for cache_item in cache_items:
-                if not cache_item.metadata:
-                    # No metadata means no URL, timestamp, or headers to attribute the
-                    # entry to; it is dropped, so say so rather than quietly shrinking
-                    # the count.
-                    unparsed.record(str(getattr(cache_item, 'key', '<unknown key>')),
-                                  'cache entry has no metadata')
+                cache_key = getattr(cache_item, 'key', None)
+                if cache_key is None:
+                    # Without a key there is no URL either, so nothing identifies what
+                    # was cached. This one really cannot be reported.
+                    unparsed.record('<unknown key>', 'cache entry has no key')
                     continue
 
+                metadata = cache_item.metadata
+                if not metadata:
+                    # No metadata means no fetch time and no headers, but the URL lives on
+                    # the key, not in the metadata, and a cache entry is evidence that the
+                    # resource was cached whether or not its time survived. The row is
+                    # kept untimed rather than dropped: the Timeline sorts untimed
+                    # artifacts last and JSONL labels them 'Not a time', so an absent time
+                    # is reported as absent instead of being invented or losing the URL.
+                    untimed_entries += 1
+
                 parsed_item = WebBrowser.CacheItem(
-                    profile=self.profile_path, url=cache_item.key.url,
-                    request_time=utils.to_datetime(cache_item.metadata.request_time.replace(tzinfo=datetime.timezone.utc), self.timezone),
+                    profile=self.profile_path, url=cache_key.url,
+                    request_time=utils.to_datetime(
+                        metadata.request_time.replace(tzinfo=datetime.timezone.utc),
+                        self.timezone) if metadata else None,
                     locations=str({'data': cache_item.data_location, 'metadata': cache_item.metadata_location}),
-                    key=cache_item.key, metadata=cache_item.metadata, data=cache_item.data, title=None)
+                    key=cache_key, metadata=metadata, data=cache_item.data, title=None)
 
                 parsed_item.row_type = row_type
                 parsed_item.data_summary = parsed_item.create_data_summary()
                 parsed_item.stringify_http_headers()
-                parsed_item.etag = (cache_item.metadata.get_attribute("etag") or [""])[0]
-                parsed_item.last_modified = (cache_item.metadata.get_attribute("last-modified") or [""])[0]
+                parsed_item.etag = (metadata.get_attribute("etag") or [""])[0] if metadata else ''
+                parsed_item.last_modified = (metadata.get_attribute("last-modified") or [""])[0] if metadata else ''
                 # The body is already in memory (omit_cached_data=False), so this costs
                 # no extra reads.
                 parsed_item.hash_body(cache_item.was_decompressed)
@@ -3803,6 +3815,10 @@ class Chrome(WebBrowser):
         except Exception as e:
             log.error(f' - Exception parsing Cache items: {e})', exc_info=True)
             return None
+
+        if untimed_entries:
+            log.info(f' - {untimed_entries} cache entries had no metadata; their URL and '
+                     f'body are reported but they carry no request time or headers')
 
         if unhashed_bodies:
             log.warning(f' - {unhashed_bodies} cached bodies were not hashed; their '

--- a/pyhindsight/browsers/webbrowser.py
+++ b/pyhindsight/browsers/webbrowser.py
@@ -827,16 +827,29 @@ class WebBrowser(object):
             if not self.data:
                 return
 
-            declared_encoding = ''
-            if self.metadata:
-                declared_encoding = (
-                    self.metadata.get_attribute('content-encoding') or [''])[0].strip()
+            if not self.metadata:
+                # Headers are what say whether these bytes are the resource or a
+                # still-encoded copy of it. Without them that cannot be established, and
+                # a digest that cannot be said to identify the resource is worse than
+                # none: it sits in the same column as every other one, looks equally
+                # authoritative, and silently fails to match.
+                return
+
+            declared_encoding = (
+                self.metadata.get_attribute('content-encoding') or [''])[0].strip()
             if declared_encoding and not was_decompressed:
                 return
 
             self.body_sha256 = hashlib.sha256(self.data).hexdigest()
 
         def stringify_http_headers(self):
+            if not self.metadata:
+                # No metadata means the headers were never recovered, which is not the
+                # same as a response that carried none. '{}' would assert the latter, so
+                # the field is left empty.
+                self.http_headers_str = ''
+                return
+
             headers = {}
             for attribute, value in self.metadata.http_header_attributes:
                 headers[attribute] = value

--- a/tests/corpus/baselines/bf4sa_2025_bob-1.json
+++ b/tests/corpus/baselines/bf4sa_2025_bob-1.json
@@ -2,7 +2,7 @@
   "data_types": {
     "chrome:autofill:entry": 12,
     "chrome:bookmark:entry": 2,
-    "chrome:cache:entry": 8227,
+    "chrome:cache:entry": 8837,
     "chrome:cookie:entry": 4738,
     "chrome:extension:installed": 14,
     "chrome:extension_storage:entry": 2967,
@@ -28,7 +28,7 @@
     "chrome:sync_data:entry": 3673
   },
   "generated_by": {
-    "generated_utc": "2026-09-04T17:01:08Z",
+    "generated_utc": "2026-09-06T00:32:15Z",
     "hindsight_version": "2026.06"
   },
   "profiles": {
@@ -47,9 +47,9 @@
           "unparsed_sources": 0
         },
         "Cache": {
-          "count": 6397,
-          "status": "partial",
-          "unparsed_records": 601,
+          "count": 6998,
+          "status": null,
+          "unparsed_records": 0,
           "unparsed_sources": 0
         },
         "Cookies": {
@@ -113,9 +113,9 @@
           "unparsed_sources": 0
         },
         "GPUCache": {
-          "count": 0,
-          "status": "partial",
-          "unparsed_records": 9,
+          "count": 9,
+          "status": null,
+          "unparsed_records": 0,
           "unparsed_sources": 0
         },
         "HSTS": {
@@ -398,5 +398,5 @@
     }
   },
   "root": "bf4sa_2025_bob-1",
-  "total_records": 64724
+  "total_records": 65334
 }

--- a/tests/corpus/baselines/bf4sa_2026_bob-2.json
+++ b/tests/corpus/baselines/bf4sa_2026_bob-2.json
@@ -2,7 +2,7 @@
   "data_types": {
     "chrome:autofill:entry": 22,
     "chrome:bookmark:entry": 2,
-    "chrome:cache:entry": 13318,
+    "chrome:cache:entry": 17764,
     "chrome:cookie:entry": 5570,
     "chrome:extension:installed": 16,
     "chrome:extension_storage:entry": 19522,
@@ -28,7 +28,7 @@
     "chrome:sync_data:entry": 8354
   },
   "generated_by": {
-    "generated_utc": "2026-09-04T17:01:42Z",
+    "generated_utc": "2026-09-06T00:32:38Z",
     "hindsight_version": "2026.06"
   },
   "profiles": {
@@ -47,9 +47,9 @@
           "unparsed_sources": 0
         },
         "Cache": {
-          "count": 6740,
-          "status": "partial",
-          "unparsed_records": 4428,
+          "count": 11168,
+          "status": null,
+          "unparsed_records": 0,
           "unparsed_sources": 0
         },
         "Cookies": {
@@ -119,9 +119,9 @@
           "unparsed_sources": 0
         },
         "GPUCache": {
-          "count": 0,
-          "status": "partial",
-          "unparsed_records": 12,
+          "count": 12,
+          "status": null,
+          "unparsed_records": 0,
           "unparsed_sources": 0
         },
         "HSTS": {
@@ -256,9 +256,9 @@
           "unparsed_sources": 0
         },
         "Cache": {
-          "count": 3887,
-          "status": "partial",
-          "unparsed_records": 4,
+          "count": 3891,
+          "status": null,
+          "unparsed_records": 0,
           "unparsed_sources": 0
         },
         "Cookies": {
@@ -316,9 +316,9 @@
           "unparsed_sources": 0
         },
         "GPUCache": {
-          "count": 0,
-          "status": "partial",
-          "unparsed_records": 2,
+          "count": 2,
+          "status": null,
+          "unparsed_records": 0,
           "unparsed_sources": 0
         },
         "HSTS": {
@@ -422,5 +422,5 @@
     }
   },
   "root": "bf4sa_2026_bob-2",
-  "total_records": 75447
+  "total_records": 79893
 }

--- a/tests/corpus/baselines/magnet.ctf_2018.json
+++ b/tests/corpus/baselines/magnet.ctf_2018.json
@@ -3,7 +3,7 @@
     "chrome:autofill:entry": 80,
     "chrome:bookmark:entry": 21,
     "chrome:bookmark:folder": 13,
-    "chrome:cache:entry": 8895,
+    "chrome:cache:entry": 8952,
     "chrome:cookie:entry": 2217,
     "chrome:extension:installed": 56,
     "chrome:file_system:entry": 1,
@@ -23,7 +23,7 @@
     "chrome:sync_data:entry": 1
   },
   "generated_by": {
-    "generated_utc": "2026-09-04T17:01:48Z",
+    "generated_utc": "2026-09-06T00:32:43Z",
     "hindsight_version": "2026.06"
   },
   "profiles": {
@@ -286,9 +286,9 @@
           "unparsed_sources": 0
         },
         "Media Cache": {
-          "count": 16,
-          "status": "partial",
-          "unparsed_records": 57,
+          "count": 73,
+          "status": null,
+          "unparsed_records": 0,
           "unparsed_sources": 0
         },
         "Preferences": {
@@ -427,5 +427,5 @@
     }
   },
   "root": "magnet.ctf_2018",
-  "total_records": 14225
+  "total_records": 14282
 }

--- a/tests/corpus/baselines/magnet.ctf_2023.json
+++ b/tests/corpus/baselines/magnet.ctf_2023.json
@@ -1,7 +1,7 @@
 {
   "data_types": {
     "chrome:autofill:entry": 24,
-    "chrome:cache:entry": 19593,
+    "chrome:cache:entry": 21368,
     "chrome:cookie:entry": 1966,
     "chrome:extension:installed": 48,
     "chrome:extension_storage:entry": 2,
@@ -27,7 +27,7 @@
     "chrome:sync_data:entry": 1732
   },
   "generated_by": {
-    "generated_utc": "2026-09-04T17:02:33Z",
+    "generated_utc": "2026-09-06T00:33:09Z",
     "hindsight_version": "2026.06"
   },
   "profiles": {
@@ -40,9 +40,9 @@
           "unparsed_sources": 0
         },
         "Cache": {
-          "count": 7238,
-          "status": "partial",
-          "unparsed_records": 10,
+          "count": 7248,
+          "status": null,
+          "unparsed_records": 0,
           "unparsed_sources": 0
         },
         "Cookies": {
@@ -296,9 +296,9 @@
           "unparsed_sources": 0
         },
         "Cache": {
-          "count": 9322,
-          "status": "partial",
-          "unparsed_records": 1763,
+          "count": 11085,
+          "status": null,
+          "unparsed_records": 0,
           "unparsed_sources": 0
         },
         "Cookies": {
@@ -552,9 +552,9 @@
           "unparsed_sources": 0
         },
         "Cache": {
-          "count": 2085,
-          "status": "partial",
-          "unparsed_records": 2,
+          "count": 2087,
+          "status": null,
+          "unparsed_records": 0,
           "unparsed_sources": 0
         },
         "Cookies": {
@@ -688,5 +688,5 @@
     }
   },
   "root": "magnet.ctf_2023",
-  "total_records": 36645
+  "total_records": 38420
 }

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -169,13 +169,33 @@ class TestCacheBodyHash(unittest.TestCase):
         self.assertEqual('https://example.test/logo.png', item.url)
         self.assertEqual(f'image/png ({len(PNG_BYTES)} bytes)', item.create_data_summary())
 
-    def test_an_entry_without_metadata_still_hashes(self):
-        # No headers means no declared encoding to disqualify the bytes.
-        item = WebBrowser.CacheItem(
+    def test_an_entry_without_metadata_is_not_hashed(self):
+        # Headers are what establish whether the bytes on disk are the resource. Without
+        # them the question is unanswerable, so no digest is recorded, for the same
+        # reason a body that failed to decompress gets none.
+        item = self._no_metadata_item()
+        item.hash_body()
+        self.assertIsNone(item.body_sha256)
+
+    def test_the_rest_of_an_entry_without_metadata_survives(self):
+        # Withholding the digest must not cost the entry. Its URL is on the key, not in
+        # the metadata, so the row still reports what was cached and how large it was.
+        item = self._no_metadata_item()
+        self.assertEqual('https://example.test/', item.url)
+        self.assertEqual(f'{len(PNG_BYTES)} bytes', item.create_data_summary())
+
+    def test_an_entry_without_metadata_reports_no_headers_rather_than_none(self):
+        # '{}' would assert a response that carried no headers, which is a different
+        # finding from headers that were never recovered.
+        item = self._no_metadata_item()
+        item.stringify_http_headers()
+        self.assertEqual('', item.http_headers_str)
+
+    @staticmethod
+    def _no_metadata_item():
+        return WebBrowser.CacheItem(
             profile='p', url='https://example.test/', title=None,
             request_time=None, locations='{}', key='k', metadata=None, data=PNG_BYTES)
-        item.hash_body()
-        self.assertEqual(PNG_SHA256, item.body_sha256)
 
 
 def _file_system_item(sha256):


### PR DESCRIPTION
get_cache dropped any entry whose metadata was missing, on the stated grounds that without it there is no URL, timestamp or headers to attribute the entry to. That was wrong about the URL: it comes from the cache key, not the metadata. Only the request time and headers are lost, and an entry still proves that resource was cached whether or not its time survived. The search that surfaced this was a real one, https://www.google.com/search?q=most+valuable+octopus..., cached and then discarded.

The row is kept untimed now. Everything downstream was already built for that and had simply never received one: timeline_sort_key puts untimed artifacts last precisely so they need not be dropped or given an invented date, and the CacheItem JSONL branch already labelled a timeless entry "Not a time" rather than asserting the 1970 visit that base_encoder's epoch would imply. Only stringify_http_headers needed a guard, and it leaves the field empty, because '{}' would assert a response that carried no headers, which is a different finding from headers that were never recovered. An entry with no key at all is still dropped and still recorded as unparsed, since nothing identifies it.

The body is not hashed when there is no metadata. Headers are what establish whether the bytes on disk are the resource or a still-encoded copy, so without them the question cannot be answered, and a digest that cannot be said to identify the resource is worse than none. This reverses test_an_entry_without_metadata_still_hashes, which was written when such entries never reached output. It governs real rows now, so the case is decided the same way as a body that failed to decompress. Two tests are added alongside it, covering that withholding the digest costs the entry nothing else and that the headers field reads as unrecovered rather than empty.

Across the six corpus datasets this recovers 6888 cache rows and takes every cache artifact's unparsed_records to zero. Two artifacts had been producing nothing at all because every entry lacked metadata: GPUCache went from 0 rows to 9 and to 12 in the bf4sa profiles, and magnet.ctf_2018's Media Cache from 16 to 73. Baselines regenerated for the four roots that moved; magnet.ctf_2019 and 2020 were left alone since only their regeneration timestamp changed.

```
bf4sa_2025_bob-1     8227 -> 8837    (+610)
bf4sa_2026_bob-2    13318 -> 17764   (+4446)
magnet.ctf_2018      8895 -> 8952    (+57)
magnet.ctf_2023     19593 -> 21368   (+1775)
```

Full suite green at 237 passed, 86 subtests.