### PR TITLE
Stop reporting cache locations for files that do not exist

### DIFF
--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -3768,6 +3768,43 @@ class Chrome(WebBrowser):
         source_item = os.path.relpath(os.path.join(path, dir_name), self.profile_path)
         unhashed_bodies = 0
         untimed_entries = 0
+        phantom_locations = 0
+
+        # The files this cache directory actually holds, so a location can be checked
+        # before it is reported as one.
+        try:
+            present_files = {entry.name for entry in os.scandir(cache_path_to_parse)}
+        except OSError:
+            present_files = set()
+
+        def describe_locations(entry):
+            """Say where an entry's metadata and body live, naming only files that exist.
+
+            ccl renders a blockfile address itself, and an uninitialized address comes
+            back as external file 'f_000000' at offset 0: a null Addr has
+            is_initialized False but still reports file_type EXTERNAL and file number 0,
+            and _get_location never checks the flag. Chromium never allocates external
+            file 0, so that name points at a file that has never existed. A path in the
+            output is an invitation to go and look at it, and a phantom one cannot be
+            told from a real one, so locations that do not resolve are left out.
+
+            Checking presence rather than special-casing 'f_000000' also covers a cache
+            directory that has been partially collected.
+            """
+            nonlocal phantom_locations
+            described = []
+            for label in ('metadata', 'data'):
+                location = getattr(entry, f'{label}_location', None)
+                file_name = getattr(location, 'file_name', None)
+                if not file_name:
+                    continue
+                if file_name not in present_files:
+                    phantom_locations += 1
+                    continue
+                offset = getattr(location, 'offset', None)
+                described.append(
+                    f'{label}: {file_name}' + (f' @ {offset}' if offset else ''))
+            return '; '.join(described)
 
         try:
             for cache_item in cache_items:
@@ -3793,7 +3830,7 @@ class Chrome(WebBrowser):
                     request_time=utils.to_datetime(
                         metadata.request_time.replace(tzinfo=datetime.timezone.utc),
                         self.timezone) if metadata else None,
-                    locations=str({'data': cache_item.data_location, 'metadata': cache_item.metadata_location}),
+                    locations=describe_locations(cache_item),
                     key=cache_key, metadata=metadata, data=cache_item.data, title=None)
 
                 parsed_item.row_type = row_type
@@ -3815,6 +3852,11 @@ class Chrome(WebBrowser):
         except Exception as e:
             log.error(f' - Exception parsing Cache items: {e})', exc_info=True)
             return None
+
+        if phantom_locations:
+            log.info(f' - {phantom_locations} cache locations named a file not present in '
+                     f'{dir_name} and were omitted; ccl reports an uninitialized address '
+                     f'as external file f_000000')
 
         if untimed_entries:
             log.info(f' - {untimed_entries} cache entries had no metadata; their URL and '

--- a/pyhindsight/browsers/firefox.py
+++ b/pyhindsight/browsers/firefox.py
@@ -2131,7 +2131,10 @@ class Firefox(WebBrowser):
                 url=parsed['url'],
                 title=None,
                 request_time=request_time,
-                locations=name,
+                # Firefox names a cache2 entry file after the SHA-1 of its cache key, so
+                # the bare name reads as a hash rather than as the location it is. The
+                # label says which it is, and matches the Cache API rows below.
+                locations=f'entry: {name}',
                 key=parsed['key'],
                 metadata=None,
                 data=None,

--- a/pyhindsight/browsers/webbrowser.py
+++ b/pyhindsight/browsers/webbrowser.py
@@ -802,7 +802,6 @@ class WebBrowser(object):
             self.http_headers_str = None
             self.etag = None
             self.last_modified = None
-            self.locations_str = None
             self.body_sha256 = None
 
         def create_data_summary(self):


### PR DESCRIPTION
Cache rows named a file that has never existed. ccl's `_get_location` doesn't check `Addr.is_initialized`, so a null data address comes back as external file `f_000000` at offset 0, and Chromium never allocates external file 0. On the Edge profile in cellebrite.ctf_2021 that was 9066 of 21748 locations.

Each location is now checked against what the cache directory actually holds and dropped if it doesn't resolve, which also covers a partially collected cache. Rows where nothing resolves leave the column empty, matching their `<no data>` summary. The column was also built by str()-ing a dict of ccl location objects, and their `__repr__` is missing its closing `>`, so the text ran together. It's formatted here now, as `metadata: data_3 @ 8192; data: f_000001`.

Firefox rows carried a bare cache2 entry filename, which is the SHA-1 of the cache key and reads as a hash rather than a location. Labelled `entry: <name>` to match the Cache API rows in the same parser.

Also drops `CacheItem.locations_str`, assigned None in `__init__` and never read.

Both ccl bugs are logged in future_work with repros. Suite green, no baselines moved.
