### PR TITLE
Stop warning that a healthy run may be useless

### DIFF
--- a/hindsight.py
+++ b/hindsight.py
@@ -258,7 +258,13 @@ def main():
     meta_table.add_column("Value", overflow="fold")
     meta_table.add_row("Start time", start_time)
     meta_table.add_row("Input directory", args.input)
-    meta_table.add_row("Profiles found", str(profile_count))
+    if analysis_session.used_input_path_as_profile:
+        # The search found nothing and fell back to the input path itself. Saying
+        # "1" here reads as a success right next to the warning that says otherwise.
+        meta_table.add_row(
+            "Profiles found", "[yellow]0 (parsing the input path as a profile)[/yellow]")
+    else:
+        meta_table.add_row("Profiles found", str(profile_count))
     if analysis_session.artifact_filter.is_active:
         meta_table.add_row("Artifacts", analysis_session.artifact_filter.describe())
     if args.browser_type:

--- a/hindsight.py
+++ b/hindsight.py
@@ -248,8 +248,9 @@ def main():
     # Print input & output directories
     analysis_session.input_path = args.input
     output_name = f'{analysis_session.output_name}.{analysis_session.selected_output_format}'
-    # Find browser profiles early so we can display the count
-    profile_paths = analysis_session.find_browser_profiles(args.input)
+    # Find browser profiles early so we can display the count. run() searches
+    # again; warn=False keeps the "no profiles found" warning to a single line.
+    profile_paths = analysis_session.find_browser_profiles(args.input, warn=False)
     profile_count = len(profile_paths)
     console.rule("Processing", style="green")
     meta_table = rich.table.Table(show_header=False, box=None)

--- a/pyhindsight/analysis.py
+++ b/pyhindsight/analysis.py
@@ -715,6 +715,9 @@ class AnalysisSession(object):
         self.fatal_error = None
         # {profile_path: detected family}; populated by find_browser_profiles().
         self.detected_profile_families = {}
+        # True when the search found no profile and fell back to treating the
+        # input path as one; set by find_browser_profiles().
+        self.used_input_path_as_profile = False
 
         if self.version is None:
             self.version = []
@@ -1139,10 +1142,15 @@ class AnalysisSession(object):
         Set ``warn=False`` to suppress the "no profiles found" warning; callers
         that run the search a second time (the early profile count in
         ``hindsight.py``) use it so the warning is logged once, not twice.
+
+        When nothing is found the input path itself is returned as a last-resort
+        profile, and ``self.used_input_path_as_profile`` is set so callers can
+        tell that fallback apart from a real single-profile result.
         """
         # Reset detection state so a re-run (and the early count in hindsight.py)
         # don't accumulate stale entries.
         self.detected_profile_families = {}
+        self.used_input_path_as_profile = False
         found_profile_paths = []
         base_dir_listing = os.listdir(base_path)
 
@@ -1169,6 +1177,7 @@ class AnalysisSession(object):
                     f"file nor a Firefox 'places.sqlite' is present there or in any "
                     f"subdirectory. Processing the input path as a Profile; analysis may not "
                     f"be very useful.")
+            self.used_input_path_as_profile = True
             found_profile_paths = [base_path]
 
         log.debug("Profile paths: " + str(found_profile_paths))

--- a/pyhindsight/analysis.py
+++ b/pyhindsight/analysis.py
@@ -1027,7 +1027,7 @@ class AnalysisSession(object):
     }
 
     @staticmethod
-    def is_profile(base_path, existing_files, warn=False):
+    def is_profile(base_path, existing_files):
         """Return the detected browser engine family for `base_path`, or None.
 
         A Chromium profile (Chrome/Edge/Brave/...) has a ``History`` SQLite file;
@@ -1042,9 +1042,6 @@ class AnalysisSession(object):
             if required_file in existing_files and os.path.isfile(os.path.join(base_path, required_file)):
                 return family
 
-        if warn:
-            log.warning(f"The profile directory {base_path} does not contain a recognized "
-                        f"browser history file (History or places.sqlite). Analysis may not be very useful.")
         return None
 
     @classmethod
@@ -1132,12 +1129,16 @@ class AnalysisSession(object):
                     found_profile_paths.extend(profile_found_in_subdir)
         return found_profile_paths
 
-    def find_browser_profiles(self, base_path):
+    def find_browser_profiles(self, base_path, warn=True):
         """Search a path for browser profiles, detecting each profile's browser family.
 
         Records the detected family (Chrome/Firefox) per profile path in
         ``self.detected_profile_families`` so ``run()`` can dispatch the right
         pipeline per profile when no ``-b`` override is given.
+
+        Set ``warn=False`` to suppress the "no profiles found" warning; callers
+        that run the search a second time (the early profile count in
+        ``hindsight.py``) use it so the warning is logged once, not twice.
         """
         # Reset detection state so a re-run (and the early count in hindsight.py)
         # don't accumulate stale entries.
@@ -1146,8 +1147,10 @@ class AnalysisSession(object):
         base_dir_listing = os.listdir(base_path)
 
         # A recognized history file (Chrome 'History' or Firefox 'places.sqlite')
-        # is the minimum required for useful analysis. Warn if not present.
-        family = self.is_profile(base_path, base_dir_listing, warn=True)
+        # is the minimum required for useful analysis. Its absence here says
+        # nothing yet: an app-data root is not itself a profile, and the profiles
+        # under it are found by the search below.
+        family = self.is_profile(base_path, base_dir_listing)
         if family:
             found_profile_paths.append(base_path)
             self.detected_profile_families[base_path] = \
@@ -1160,7 +1163,12 @@ class AnalysisSession(object):
         # If we did not find any valid Profiles, attempt to process the input
         # path as a Profile
         if not found_profile_paths:
-            log.warning("No Profile paths found; processing input path as a Profile")
+            if warn:
+                log.warning(
+                    f"No browser profiles found under {base_path}; neither a Chrome 'History' "
+                    f"file nor a Firefox 'places.sqlite' is present there or in any "
+                    f"subdirectory. Processing the input path as a Profile; analysis may not "
+                    f"be very useful.")
             found_profile_paths = [base_path]
 
         log.debug("Profile paths: " + str(found_profile_paths))

--- a/tests/test_profile_discovery_warning.py
+++ b/tests/test_profile_discovery_warning.py
@@ -1,0 +1,94 @@
+import logging
+import os
+import tempfile
+import unittest
+
+from pyhindsight import analysis
+from pyhindsight.analysis import AnalysisSession
+
+
+class CapturingHandler(logging.Handler):
+    """Collect log records emitted during profile discovery."""
+
+    def __init__(self):
+        super().__init__()
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+class TestProfileDiscoveryWarning(unittest.TestCase):
+    """The 'analysis may not be useful' warning fires only when nothing was found.
+
+    Aiming Hindsight at an app-data root is the normal invocation: the root is
+    not itself a profile, so a warning raised before the search recurses fires on
+    every healthy run. The warning is only meaningful once the search is done.
+    """
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.handler = CapturingHandler()
+        self.original_handlers = analysis.log.handlers
+        self.original_propagate = analysis.log.propagate
+        analysis.log.handlers = [self.handler]
+        analysis.log.propagate = False
+        analysis.log.setLevel(logging.WARNING)
+
+    def tearDown(self):
+        analysis.log.handlers = self.original_handlers
+        analysis.log.propagate = self.original_propagate
+
+    def warnings_from(self, base_path, **kwargs):
+        self.handler.records = []
+        found = AnalysisSession().find_browser_profiles(base_path, **kwargs)
+        warnings = [r.getMessage() for r in self.handler.records
+                    if r.levelno >= logging.WARNING]
+        return found, warnings
+
+    def make_chrome_profile(self, *parts):
+        path = os.path.join(self.root, *parts)
+        os.makedirs(path)
+        open(os.path.join(path, 'History'), 'w').close()
+        return path
+
+    def test_app_data_root_with_profiles_below_it_warns_nothing(self):
+        default = self.make_chrome_profile('User Data', 'Default')
+        second = self.make_chrome_profile('User Data', 'Profile 1')
+
+        found, warnings = self.warnings_from(os.path.join(self.root, 'User Data'))
+
+        self.assertEqual({default, second}, set(found))
+        self.assertEqual([], warnings)
+
+    def test_profile_passed_directly_warns_nothing(self):
+        default = self.make_chrome_profile('Default')
+
+        found, warnings = self.warnings_from(default)
+
+        self.assertEqual([default], found)
+        self.assertEqual([], warnings)
+
+    def test_path_with_no_profile_anywhere_below_it_warns_once(self):
+        os.makedirs(os.path.join(self.root, 'sub', 'deeper'))
+        open(os.path.join(self.root, 'sub', 'readme.txt'), 'w').close()
+
+        found, warnings = self.warnings_from(self.root)
+
+        # The input path is still processed as a profile, as a last resort.
+        self.assertEqual([self.root], found)
+        self.assertEqual(1, len(warnings), warnings)
+        self.assertIn('No browser profiles found', warnings[0])
+        self.assertIn(self.root, warnings[0])
+
+    def test_warn_false_silences_the_duplicate_from_the_early_count(self):
+        # hindsight.py counts profiles before run() searches again; only one of
+        # the two searches should log.
+        found, warnings = self.warnings_from(self.root, warn=False)
+
+        self.assertEqual([self.root], found)
+        self.assertEqual([], warnings)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_profile_discovery_warning.py
+++ b/tests/test_profile_discovery_warning.py
@@ -41,7 +41,8 @@ class TestProfileDiscoveryWarning(unittest.TestCase):
 
     def warnings_from(self, base_path, **kwargs):
         self.handler.records = []
-        found = AnalysisSession().find_browser_profiles(base_path, **kwargs)
+        self.session = AnalysisSession()
+        found = self.session.find_browser_profiles(base_path, **kwargs)
         warnings = [r.getMessage() for r in self.handler.records
                     if r.levelno >= logging.WARNING]
         return found, warnings
@@ -60,6 +61,7 @@ class TestProfileDiscoveryWarning(unittest.TestCase):
 
         self.assertEqual({default, second}, set(found))
         self.assertEqual([], warnings)
+        self.assertFalse(self.session.used_input_path_as_profile)
 
     def test_profile_passed_directly_warns_nothing(self):
         default = self.make_chrome_profile('Default')
@@ -68,6 +70,7 @@ class TestProfileDiscoveryWarning(unittest.TestCase):
 
         self.assertEqual([default], found)
         self.assertEqual([], warnings)
+        self.assertFalse(self.session.used_input_path_as_profile)
 
     def test_path_with_no_profile_anywhere_below_it_warns_once(self):
         os.makedirs(os.path.join(self.root, 'sub', 'deeper'))
@@ -75,8 +78,10 @@ class TestProfileDiscoveryWarning(unittest.TestCase):
 
         found, warnings = self.warnings_from(self.root)
 
-        # The input path is still processed as a profile, as a last resort.
+        # The input path is still processed as a profile, as a last resort, but
+        # the caller can tell that apart from a genuine single-profile result.
         self.assertEqual([self.root], found)
+        self.assertTrue(self.session.used_input_path_as_profile)
         self.assertEqual(1, len(warnings), warnings)
         self.assertIn('No browser profiles found', warnings[0])
         self.assertIn(self.root, warnings[0])
@@ -88,6 +93,8 @@ class TestProfileDiscoveryWarning(unittest.TestCase):
 
         self.assertEqual([self.root], found)
         self.assertEqual([], warnings)
+        # Silencing the warning must not silence the fallback itself.
+        self.assertTrue(self.session.used_input_path_as_profile)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
find_browser_profiles warned that the input directory held no recognized history
file before it recursed, so pointing Hindsight at a User Data root always logged
"Analysis may not be very useful", twice, then parsed the profiles underneath it
anyway. The warning only means something once the search has finished and found
nothing, so it moves below the recursion and merges with the "No Profile paths
found" warning that was already there. The doubling was separate: hindsight.py
searches once for the early profile count and run() searches again, so the early
call now passes warn=False.

Second commit: when the search finds nothing it falls back to the input path, and
the console counted that as "Profiles found  1" right above the warning saying
otherwise. It now reads "0 (parsing the input path as a profile)".

The genuine no-profile case is as loud as before. Checked against
magnet.ctf_2018, 4 profiles, 13,899 items: no warnings, previously two. Full
suite 239 passed.
