### PR TITLE
Find extensions whose version directory has no dot in it

### DIFF
--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -2149,8 +2149,11 @@ class Chrome(WebBrowser):
             # The sort is reverse=True (newest first), so a non-numeric component
             # ranks *below* every numeric one to land last: a malformed directory
             # should never be preferred over a real version, and must not crash the
-            # comparison the way int(part) did.
-            return (1, int(part), '') if part.isdigit() else (0, 0, part)
+            # comparison the way int(part) did. isdigit() alone is not enough of a
+            # guard, since it is true for characters like the superscript '2' that
+            # int() then rejects.
+            numeric = part.isascii() and part.isdigit()
+            return (1, int(part), '') if numeric else (0, 0, part)
 
         def version_sort_key(version_dir):
             # Split the `_<n>` suffix off before splitting the version on '.'. Left

--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -2134,22 +2134,33 @@ class Chrome(WebBrowser):
     def load_extension_manifest(extension_path):
         # Get listing of the contents of extension_id directory;
         # this should contain subdirectories for each version of the extension.
-        # Glob should filter out extraneous files (like $I30 from FTK).
-        ext_version_listing = list(pathlib.Path(extension_path).glob("*.*_*"))
+        # Version directories are named `<version>_<n>`, so the trailing `_<n>` is the real
+        # marker; matching on it (rather than on a dot) still filters out extraneous files
+        # like $I30 from FTK, while keeping single-component versions such as `7_0`, which
+        # were common in early Chrome and were previously never found at all.
+        ext_version_listing = [
+            entry for entry in pathlib.Path(extension_path).glob("*_*") if entry.is_dir()]
 
         # Connect to manifest.json in the latest version directory
         # The version could be missing leading zeros in the string, so this sort accounts
         # for that. Non-numeric components sort last rather than raising: one oddly-named
         # directory used to abort the whole Extensions parse.
+        def component_key(part):
+            # The sort is reverse=True (newest first), so a non-numeric component
+            # ranks *below* every numeric one to land last: a malformed directory
+            # should never be preferred over a real version, and must not crash the
+            # comparison the way int(part) did.
+            return (1, int(part), '') if part.isdigit() else (0, 0, part)
+
         def version_sort_key(version_dir):
-            parts = []
-            for part in version_dir.name.split('.'):
-                # The sort is reverse=True (newest first), so a non-numeric component
-                # ranks *below* every numeric one to land last: a malformed directory
-                # should never be preferred over a real version, and must not crash the
-                # comparison the way int(part) did.
-                parts.append((1, int(part), '') if part.isdigit() else (0, 0, part))
-            return parts
+            # Split the `_<n>` suffix off before splitting the version on '.'. Left
+            # attached it mis-orders the last component: '3_0' is not a digit string, so it
+            # compared as text and ranked 1.2.3_0 above 1.2.10_0, and int('3_0') is 30 to
+            # Python, since underscores are legal in integer literals.
+            version, separator, suffix = version_dir.name.rpartition('_')
+            if not separator:
+                version, suffix = version_dir.name, ''
+            return [component_key(part) for part in version.split('.')], component_key(suffix)
 
         for version in sorted(ext_version_listing, reverse=True, key=version_sort_key):
             manifest_path = version / 'manifest.json'

--- a/tests/corpus/baselines/magnet.ctf_2018.json
+++ b/tests/corpus/baselines/magnet.ctf_2018.json
@@ -23,7 +23,7 @@
     "chrome:sync_data:entry": 1
   },
   "generated_by": {
-    "generated_utc": "2026-09-06T00:32:43Z",
+    "generated_utc": "2026-09-07T18:11:34Z",
     "hindsight_version": "2026.06"
   },
   "profiles": {
@@ -60,10 +60,10 @@
           "unparsed_sources": 0
         },
         "Extensions": {
-          "count": 3,
-          "status": "partial",
+          "count": 4,
+          "status": null,
           "unparsed_records": 0,
-          "unparsed_sources": 1
+          "unparsed_sources": 0
         },
         "HSTS": {
           "count": 5,

--- a/tests/test_chrome_robustness.py
+++ b/tests/test_chrome_robustness.py
@@ -85,14 +85,34 @@ class TestExtensionVersionDirectories(unittest.TestCase):
             manifest, version = Chrome.load_extension_manifest(ext)
             self.assertEqual('New', manifest['name'])
 
-    def test_a_stray_file_is_not_mistaken_for_a_version_directory(self):
-        # $I30 from FTK has no underscore, but other strays do; only directories hold
-        # a manifest.
+    def test_single_and_multi_component_versions_order_together(self):
+        # Widening the glob means both shapes can now appear side by side, so they have
+        # to compare against each other and not just among themselves: 7 > 1.2.3.
+        with tempfile.TemporaryDirectory() as tmp:
+            ext = self._extension(tmp, {
+                '7_0': {'name': 'Single', 'version': '7'},
+                '1.2.3_0': {'name': 'Multi', 'version': '1.2.3'},
+            })
+            manifest, version = Chrome.load_extension_manifest(ext)
+            self.assertEqual('Single', manifest['name'])
+            self.assertEqual('7_0', version)
+
+    def test_a_non_directory_matching_the_glob_is_ignored(self):
+        # The old glob's dot also kept out extraneous files such as $I30 from FTK.
+        # Widening it to "*_*" gives that job to the is_dir() filter instead. `.tmp`
+        # here is deliberately a name that sorts *first*, so without the filter it is
+        # the one the sort reaches for before anything else. It still lands on the right
+        # manifest either way, because opening a path under a file raises OSError and the
+        # loop moves on, so the assertion that earns its keep is the quiet log: the right
+        # answer reached by way of a logged error is not the same as the right answer.
         with tempfile.TemporaryDirectory() as tmp:
             ext = self._extension(tmp, {'1.0.0_0': {'name': 'Good', 'version': '1.0.0'}})
-            (ext / 'zz_notes.txt').write_text('stray', encoding='utf-8')
-            manifest, version = Chrome.load_extension_manifest(ext)
+            (ext / '9.9.9_0.tmp').write_text('not a directory', encoding='utf-8')
+            (ext / '$I30_junk').write_text('not a directory', encoding='utf-8')
+            with self.assertNoLogs('pyhindsight.browsers.chrome', level='ERROR'):
+                manifest, version = Chrome.load_extension_manifest(ext)
             self.assertEqual('Good', manifest['name'])
+            self.assertEqual('1.0.0_0', version)
 
     def test_a_non_ascii_digit_does_not_raise(self):
         # str.isdigit() is true for characters like the superscript '2', which int()

--- a/tests/test_chrome_robustness.py
+++ b/tests/test_chrome_robustness.py
@@ -54,6 +54,46 @@ class TestExtensionVersionDirectories(unittest.TestCase):
             # first place (a string sort would pick 1.2.3).
             self.assertEqual('New', manifest['name'])
 
+    def test_a_single_component_version_directory_is_found(self):
+        # Early Chrome unpacked extensions to names like `7_0`, with no dot. Globbing
+        # for `*.*_*` never matched those, so a fully intact extension was reported
+        # unreadable.
+        with tempfile.TemporaryDirectory() as tmp:
+            ext = self._extension(tmp, {'7_0': {'name': 'Mail', 'version': '7'}})
+            manifest, version = Chrome.load_extension_manifest(ext)
+            self.assertEqual('Mail', manifest['name'])
+            self.assertEqual('7_0', version)
+
+    def test_the_last_component_is_ordered_numerically(self):
+        # The `_<n>` suffix rides on the last component, so `3_0` and `10_0` used to be
+        # compared as text and picked 1.2.3 as newer than 1.2.10.
+        with tempfile.TemporaryDirectory() as tmp:
+            ext = self._extension(tmp, {
+                '1.2.3_0': {'name': 'Old', 'version': '1.2.3'},
+                '1.2.10_0': {'name': 'New', 'version': '1.2.10'},
+            })
+            manifest, version = Chrome.load_extension_manifest(ext)
+            self.assertEqual('New', manifest['name'])
+            self.assertEqual('1.2.10_0', version)
+
+    def test_single_component_versions_are_ordered_numerically(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ext = self._extension(tmp, {
+                '7_0': {'name': 'Old', 'version': '7'},
+                '10_0': {'name': 'New', 'version': '10'},
+            })
+            manifest, version = Chrome.load_extension_manifest(ext)
+            self.assertEqual('New', manifest['name'])
+
+    def test_a_stray_file_is_not_mistaken_for_a_version_directory(self):
+        # $I30 from FTK has no underscore, but other strays do; only directories hold
+        # a manifest.
+        with tempfile.TemporaryDirectory() as tmp:
+            ext = self._extension(tmp, {'1.0.0_0': {'name': 'Good', 'version': '1.0.0'}})
+            (ext / 'zz_notes.txt').write_text('stray', encoding='utf-8')
+            manifest, version = Chrome.load_extension_manifest(ext)
+            self.assertEqual('Good', manifest['name'])
+
     def test_missing_manifest_returns_none_rather_than_raising(self):
         with tempfile.TemporaryDirectory() as tmp:
             ext = pathlib.Path(tmp, 'abcdefghijklmnopabcdefghijklmnop')

--- a/tests/test_chrome_robustness.py
+++ b/tests/test_chrome_robustness.py
@@ -94,6 +94,17 @@ class TestExtensionVersionDirectories(unittest.TestCase):
             manifest, version = Chrome.load_extension_manifest(ext)
             self.assertEqual('Good', manifest['name'])
 
+    def test_a_non_ascii_digit_does_not_raise(self):
+        # str.isdigit() is true for characters like the superscript '2', which int()
+        # then refuses, so testing it alone put the ValueError back into the sort.
+        with tempfile.TemporaryDirectory() as tmp:
+            ext = self._extension(tmp, {
+                '1.0.0_0': {'name': 'Good', 'version': '1.0.0'},
+                '²_0': {'name': 'Odd', 'version': '?'},
+            })
+            manifest, version = Chrome.load_extension_manifest(ext)
+            self.assertEqual('Good', manifest['name'])
+
     def test_missing_manifest_returns_none_rather_than_raising(self):
         with tempfile.TemporaryDirectory() as tmp:
             ext = pathlib.Path(tmp, 'abcdefghijklmnopabcdefghijklmnop')


### PR DESCRIPTION
Fixes #344.

`load_extension_manifest` globbed version directories with `*.*_*`, which requires a dot in the name. An extension unpacked to `7_0` rather than `1.2.3_0` was never found, so it came out as unreadable with no name, version or permissions even though its manifest.json was right there. It now matches on the trailing `_<n>`, which is the real marker, and keeps only directories.

The sort key had the related problem the issue describes. Splitting the name on `.` leaves the `_<n>` suffix on the last component, and `3_0` is not a digit string, so it was compared as text and ranked `1.2.3_0` above `1.2.10_0`. Reading it as a number would have been just as wrong, since Python allows underscores in integer literals and `int('3_0')` is 30. The suffix is now split off first.

I checked the whole corpus: magnet.ctf_2018 has the only single-component version directory among the 56 there, and it is the only extension whose selected version changes, so "latest version wins" still holds. Its baseline moves accordingly, Extensions from 3 records and one unparsed source to 4 and none, and that profile's Extensions status is no longer partial. Four unit tests added, three of which fail without the fix.

Second commit fixes something adjacent I noticed in the same sort key. `str.isdigit()` is true for characters like the superscript '2', which `int()` then refuses, so a version directory named `²_0` would raise straight out of the guard that exists to stop exactly that. It now requires ASCII, with a test that fails without it.
