### PR TITLE
Find extensions whose version directory has a single component

### DIFF
--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -2134,16 +2134,27 @@ class Chrome(WebBrowser):
     def load_extension_manifest(extension_path):
         # Get listing of the contents of extension_id directory;
         # this should contain subdirectories for each version of the extension.
-        # Glob should filter out extraneous files (like $I30 from FTK).
-        ext_version_listing = list(pathlib.Path(extension_path).glob("*.*_*"))
+        # The real marker of a version directory is the trailing `_<n>` unpack counter,
+        # not a dot: a single-component version is unpacked to `7_0`, with no dot at all.
+        # Globbing "*.*_*" required one and so never found those, and the extension was
+        # reported unreadable with its manifest.json sitting there intact. Filter to
+        # directories, which is what the old glob's dot was really buying (it also kept
+        # out extraneous files like $I30 from FTK).
+        ext_version_listing = [
+            path for path in pathlib.Path(extension_path).glob("*_*") if path.is_dir()]
 
         # Connect to manifest.json in the latest version directory
         # The version could be missing leading zeros in the string, so this sort accounts
         # for that. Non-numeric components sort last rather than raising: one oddly-named
         # directory used to abort the whole Extensions parse.
         def version_sort_key(version_dir):
+            # Strip the `_<n>` unpack counter before splitting on '.'. It is not part of
+            # the version, and leaving it on made the *last* component of every ordinary
+            # name non-numeric ('3_0', not '3'), so every name fell to the string branch
+            # there: 1.2.3_0 then sorted above 1.2.10_0 because '3_0' > '10_0'.
+            version, _, _ = version_dir.name.rpartition('_')
             parts = []
-            for part in version_dir.name.split('.'):
+            for part in (version or version_dir.name).split('.'):
                 # The sort is reverse=True (newest first), so a non-numeric component
                 # ranks *below* every numeric one to land last: a malformed directory
                 # should never be preferred over a real version, and must not crash the

--- a/tests/test_chrome_robustness.py
+++ b/tests/test_chrome_robustness.py
@@ -54,6 +54,54 @@ class TestExtensionVersionDirectories(unittest.TestCase):
             # first place (a string sort would pick 1.2.3).
             self.assertEqual('New', manifest['name'])
 
+    def test_a_single_component_version_directory_is_found(self):
+        # `7_0` carries no dot, so the old "*.*_*" glob never listed it and the
+        # extension was reported unreadable with its manifest.json sitting there.
+        # Single-component versions were common in early Chrome, so this skews toward
+        # older profiles.
+        with tempfile.TemporaryDirectory() as tmp:
+            ext = self._extension(tmp, {'7_0': {'name': 'Mail', 'version': '7'}})
+            manifest, version = Chrome.load_extension_manifest(ext)
+            self.assertEqual('Mail', manifest['name'])
+            self.assertEqual('7_0', version)
+
+    def test_the_unpack_counter_does_not_contaminate_the_last_component(self):
+        # The `_<n>` suffix is an unpack counter, not part of the version. Splitting on
+        # '.' without stripping it first left the last component as '3_0' rather than
+        # '3', which is not a digit, so *every* ordinary name fell to the non-numeric
+        # branch there and was compared as a string: '3_0' > '10_0' picked 1.2.3.
+        with tempfile.TemporaryDirectory() as tmp:
+            ext = self._extension(tmp, {
+                '1.2.3_0': {'name': 'Old', 'version': '1.2.3'},
+                '1.2.10_0': {'name': 'New', 'version': '1.2.10'},
+            })
+            manifest, version = Chrome.load_extension_manifest(ext)
+            self.assertEqual('New', manifest['name'])
+            self.assertEqual('1.2.10_0', version)
+
+    def test_single_and_multi_component_versions_order_together(self):
+        # Widening the glob means both shapes can now appear side by side, so they have
+        # to compare against each other and not just among themselves: 7 > 1.2.3.
+        with tempfile.TemporaryDirectory() as tmp:
+            ext = self._extension(tmp, {
+                '7_0': {'name': 'Single', 'version': '7'},
+                '1.2.3_0': {'name': 'Multi', 'version': '1.2.3'},
+            })
+            manifest, version = Chrome.load_extension_manifest(ext)
+            self.assertEqual('Single', manifest['name'])
+            self.assertEqual('7_0', version)
+
+    def test_a_non_directory_matching_the_glob_is_ignored(self):
+        # The old glob's dot also kept out extraneous files such as $I30 from FTK.
+        # Widening it to "*_*" gives that job to the is_dir() filter instead.
+        with tempfile.TemporaryDirectory() as tmp:
+            ext = self._extension(tmp, {'1.0.0_0': {'name': 'Good', 'version': '1.0.0'}})
+            (ext / '9.9.9_0.tmp').write_text('not a directory', encoding='utf-8')
+            (ext / '$I30_junk').write_text('not a directory', encoding='utf-8')
+            manifest, version = Chrome.load_extension_manifest(ext)
+            self.assertEqual('Good', manifest['name'])
+            self.assertEqual('1.0.0_0', version)
+
     def test_missing_manifest_returns_none_rather_than_raising(self):
         with tempfile.TemporaryDirectory() as tmp:
             ext = pathlib.Path(tmp, 'abcdefghijklmnopabcdefghijklmnop')


### PR DESCRIPTION
Closes #344.

`load_extension_manifest` globbed version directories with `"*.*_*"`, which requires a dot. An extension unpacked to `7_0` was never listed, so it was reported unreadable with its `manifest.json` sitting there intact. The glob widens to `"*_*"` — the trailing `_<n>` unpack counter is the real marker — and the dot's other job, keeping out extraneous files like `$I30` from FTK, moves to an explicit `is_dir()` filter.

### On the second bug

The issue reports it as `int('7_0') == 70`, since Python accepts underscores in integer literals. **That path is already gone**: the `isdigit()` guard added for non-numeric components sends `'7_0'` to the string branch rather than to `int()`. But the underlying mistake — not stripping the `_<n>` counter before splitting on `'.'` — is still there, and the string branch is wrong for the same reason. It is also much wider than the issue suggests:

The last component of *every* ordinary version directory is `'3_0'`, not `'3'`. That is not a digit, so **every** name falls to the non-numeric branch on its last component and is compared as a string. Measured on `main`:

| directories | picked on `main` | correct |
| --- | --- | --- |
| `1.2.3_0`, `1.2.10_0` | `1.2.3_0` | `1.2.10_0` |
| `7_0` | *(not found)* | `7_0` |

`'3_0' > '10_0'` as strings, so the older version wins. The existing `test_highest_numeric_version_still_wins` does not catch it because its two names differ in the *second* component, where the numeric branch is still reached.

So the counter is now stripped before the split, which fixes ordering for all names rather than only the single-component ones the glob change admits.

### Verification

Reproduced on exactly the case the issue names — extension `pjkljhegncpnkpknbcohdijeoejaedia` with version directory `7_0`, the only single-component version directory in the corpus.

Four new tests. Three of them fail on `main` and pass here:

```
FAILED test_a_single_component_version_directory_is_found
FAILED test_single_and_multi_component_versions_order_together
FAILED test_the_unpack_counter_does_not_contaminate_the_last_component
```

The fourth pins that a non-directory matching the widened glob is still ignored, which is what the old dot was buying.

Full suite on this branch: **243 passed, 2 skipped, 80 subtests passed**. Python 3.12.4, Windows.

### One thing left open

The issue also floats filtering on `^\d+(\.\d+)*_\d+$` instead of the glob. I went with the glob-plus-`is_dir()` option because the sort key already ranks malformed names last deliberately (`test_a_real_version_is_preferred_over_a_malformed_one`), and a regex filter would drop those directories entirely rather than deprioritising them — a behaviour change beyond this issue. Happy to switch if you would rather they were excluded outright.