### PR TITLE
Skip database_metadata cleanly and report the schema version it carries

### DIFF
--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -52,6 +52,12 @@ SECONDARY_CACHE_DIRS = [
     ('DawnGraphiteCache', 'dawn graphite', 'dawn-cache'),
 ]
 
+# The Site Characteristics LevelDB carries a `database_metadata` record whose value is
+# the store's bare schema version. This is the one this parser's SiteDataProto was built
+# against; anything else is parsed anyway but reported, since a schema change is exactly
+# what would make the output quietly wrong.
+SITE_CHARACTERISTICS_SCHEMA_VERSION = b'1'
+
 
 class Chrome(WebBrowser):
     def __init__(self, profile_path, browser_name=None, cache_path=None, version=None, timezone=None,
@@ -4599,8 +4605,27 @@ class Chrome(WebBrowser):
                 from pyhindsight.lib.proto.components.performance_manager.persistence.site_data.site_data_pb2 import SiteDataProto
 
                 if item['key'] == b'database_metadata':
-                    if item['value'] != b'1':
-                        log.warning(f' - Expected type 1; got type {item["value"].encode()}. Trying to parse anyway.')
+                    # Bookkeeping, not a SiteDataProto: the value is the store's bare
+                    # schema version. Surface it as parser context rather than dropping
+                    # it on the floor, then skip the record.
+                    #
+                    # The version warning used to call .encode() on item['value'], which
+                    # is bytes and so has no .encode(). On any store not at the expected
+                    # version -- b'2' is in the wild -- that raised AttributeError before
+                    # reaching the `continue`, and the record surfaced through the outer
+                    # handler as `Exception parsing SiteDataProto`. It fires on healthy
+                    # profiles, so it was pure noise, and noise that trains the reader to
+                    # skim past errors in the log.
+                    schema_version = item['value'].decode('utf-8', errors='replace')
+                    if item['value'] == SITE_CHARACTERISTICS_SCHEMA_VERSION:
+                        log.info(f' - Site Characteristics schema version {schema_version}')
+                    else:
+                        # The remaining records are still parsed; only this one is skipped.
+                        log.warning(
+                            f' - Site Characteristics schema version {schema_version}; this parser '
+                            f'was written against version '
+                            f'{SITE_CHARACTERISTICS_SCHEMA_VERSION.decode()}. Parsing the records '
+                            f'anyway.')
                     continue
 
                 raw_proto = item['value']

--- a/tests/test_site_characteristics_metadata.py
+++ b/tests/test_site_characteristics_metadata.py
@@ -1,0 +1,101 @@
+import logging
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from pyhindsight.browsers.chrome import Chrome
+
+
+class _CapturingHandler(logging.Handler):
+    def __init__(self):
+        super().__init__(level=logging.DEBUG)
+        self.records = []
+
+    def emit(self, record):
+        self.records.append((record.levelno, record.getMessage()))
+
+
+class _LogCapture:
+    """Capture everything pyhindsight.browsers.chrome logs during a block."""
+
+    def __enter__(self):
+        self.handler = _CapturingHandler()
+        self.logger = logging.getLogger('pyhindsight.browsers.chrome')
+        self.previous_level = self.logger.level
+        self.logger.addHandler(self.handler)
+        self.logger.setLevel(logging.DEBUG)
+        return self
+
+    def __exit__(self, *exc):
+        self.logger.removeHandler(self.handler)
+        self.logger.setLevel(self.previous_level)
+        return False
+
+    def messages(self, level=None):
+        return [m for lvl, m in self.handler.records if level is None or lvl == level]
+
+
+class TestSiteCharacteristicsDatabaseMetadata(unittest.TestCase):
+    """`database_metadata` is bookkeeping, not a SiteDataProto.
+
+    Its value is the store's bare schema version. The record must be skipped, and the
+    version it carries reported rather than discarded -- and neither path may raise.
+    """
+
+    def _run(self, metadata_value):
+        with tempfile.TemporaryDirectory() as tmp:
+            sc_dir = os.path.join(tmp, 'Site Characteristics Database')
+            os.makedirs(sc_dir)
+
+            browser = Chrome.__new__(Chrome)
+            browser.profile_path = tmp
+            browser.timezone = None
+            browser.parsed_artifacts = []
+            browser.origin_hashes = {}
+            browser.build_md5_hash_list_of_origins = lambda: None
+
+            record = {
+                'key': b'database_metadata', 'value': metadata_value,
+                'seq': 1, 'state': 'Live', 'file_type': 'Log',
+            }
+            with mock.patch('pyhindsight.utils.get_ldb_records', return_value=[record]):
+                with _LogCapture() as captured:
+                    count = browser.get_site_characteristics(tmp, 'Site Characteristics Database')
+            return count, captured, browser.parsed_artifacts
+
+    def test_the_expected_version_is_skipped_and_reported(self):
+        count, captured, artifacts = self._run(b'1')
+
+        self.assertEqual(0, count)
+        self.assertEqual([], artifacts)
+        self.assertTrue(
+            any('schema version 1' in m for m in captured.messages(logging.INFO)),
+            captured.messages())
+
+    def test_an_unexpected_version_warns_without_raising(self):
+        # b'2' is in the wild. The version warning used to call .encode() on a bytes
+        # value, which raised AttributeError before reaching the skip, so the record
+        # surfaced as `Exception parsing SiteDataProto` on healthy profiles.
+        count, captured, artifacts = self._run(b'2')
+
+        self.assertEqual(0, count)
+        self.assertEqual([], artifacts)
+        self.assertTrue(
+            any('schema version 2' in m for m in captured.messages(logging.WARNING)),
+            captured.messages())
+        self.assertFalse(
+            [m for m in captured.messages(logging.ERROR) if 'SiteDataProto' in m],
+            captured.messages(logging.ERROR))
+
+    def test_an_undecodable_version_still_does_not_raise(self):
+        count, captured, artifacts = self._run(b'\xff\xfe')
+
+        self.assertEqual(0, count)
+        self.assertFalse(
+            [m for m in captured.messages(logging.ERROR) if 'SiteDataProto' in m],
+            captured.messages(logging.ERROR))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #332.

### What was actually wrong

The `database_metadata` skip the issue asks for **is already there** — but it is unreachable on exactly the profiles that hit this, because the version check guarding it raises first:

```python
if item['key'] == b'database_metadata':
    if item['value'] != b'1':
        log.warning(f' - Expected type 1; got type {item["value"].encode()}. ...')
    continue
```

`item['value']` is `bytes`. `bytes` has no `.encode()`. So on any store whose version is not `b'1'` — `b'2'` is what the corpus carries — that line raises `AttributeError` **before** reaching the `continue`, and the record falls through to the outer handler as `Exception parsing SiteDataProto`. That is the traceback in the issue, and it is why it looks like the record is being parsed as a proto when the code plainly says to skip it.

So this is the str/bytes mix-up the issue's closing note asks for a glance at. It is not *near* the problem; it **is** the problem.

Nothing was ever lost — the record was skipped either way, just through the exception handler instead of the branch written for it.

### The fix

- Decode rather than encode, so the branch reaches its `continue`.
- Surface the schema version as parser context rather than discarding it, as the issue suggests: info at the expected version, a warning otherwise. A schema change is exactly what would make this parser's output quietly wrong, so it is worth saying out loud.
- The expected version becomes a module-level constant next to `SECONDARY_CACHE_DIRS`.
- Reword the message. The old text read `Trying to parse anyway.` immediately before a `continue`, which reads as a contradiction — it meant the rest of the store, not this record.

### Verification

Three tests driving `get_site_characteristics` with a stubbed `get_ldb_records`, covering `b'1'`, `b'2'` and an undecodable value. All three fail on `main`:

```
FAILED test_the_expected_version_is_skipped_and_reported
FAILED test_an_unexpected_version_warns_without_raising
FAILED test_an_undecodable_version_still_does_not_raise
```

Full suite on this branch: **242 passed, 2 skipped, 80 subtests passed**.

I did not have the `magnet.ctf_2020` corpus dataset to hand, so the reproduction here is the synthetic record from the issue's own log line rather than a corpus run — the record shape is copied verbatim from it.