### PR TITLE
Stop the SQLite timeline table dropping rows with nothing said

### DIFF
--- a/pyhindsight/analysis.py
+++ b/pyhindsight/analysis.py
@@ -3209,6 +3209,7 @@ class AnalysisSession(object):
                     return str(value)
                 return value
 
+            unhandled_timeline = collections.Counter()
             for item in self.parsed_artifacts:
                 if item.row_type.startswith('url'):
                     c.execute(
@@ -3301,12 +3302,24 @@ class AnalysisSession(object):
                         (item.row_type, sql_date(friendly_date(item.timestamp)), item.url, item.name, item.value,
                          item.interpretation, item.profile, item.source_item))
 
-                elif item.row_type.startswith(('preference', 'site setting', 'notification', 'session', 'permission action', 'profile creation')):
+                elif item.row_type.startswith(('preference', 'site setting', 'notification', 'session',
+                                               'permission action', 'profile creation', 'extension')):
                     c.execute(
                         'INSERT INTO timeline (type, timestamp, url, title, value, interpretation, profile, source_item) '
                         'VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
                         (item.row_type, sql_date(friendly_date(item.timestamp)), item.url, item.name, item.value,
                          item.interpretation, item.profile, item.source_item))
+
+                else:
+                    # Previously fell through with no branch and no message, the way every
+                    # Service Worker row used to go missing from the storage table. The
+                    # else matters more than any one branch: it is what makes the next
+                    # unhandled row_type a reported number rather than a silent absence.
+                    unhandled_timeline[item.row_type] += 1
+
+            for row_type, count in unhandled_timeline.most_common():
+                log.error(f'{count} "{row_type}" record(s) are MISSING from the SQLite '
+                          f'timeline table; no INSERT branch handles that row_type')
 
             unhandled_storage = collections.Counter()
             for item in self.parsed_storage:

--- a/tests/test_sqlite_timeline_dispatch.py
+++ b/tests/test_sqlite_timeline_dispatch.py
@@ -1,0 +1,113 @@
+import datetime
+import logging
+import os
+import sqlite3
+import tempfile
+import unittest
+
+from pyhindsight.analysis import AnalysisSession
+from pyhindsight.browsers.chrome import Chrome
+
+
+class _ErrorCapture:
+    """Capture what pyhindsight.analysis logs at ERROR during a block."""
+
+    def __enter__(self):
+        self.messages = []
+        capture = self
+
+        class _Handler(logging.Handler):
+            def emit(self, record):
+                if record.levelno >= logging.ERROR:
+                    capture.messages.append(record.getMessage())
+
+        self.handler = _Handler(level=logging.DEBUG)
+        self.logger = logging.getLogger('pyhindsight.analysis')
+        self.previous_level = self.logger.level
+        self.logger.addHandler(self.handler)
+        self.logger.setLevel(logging.DEBUG)
+        return self
+
+    def __exit__(self, *exc):
+        self.logger.removeHandler(self.handler)
+        self.logger.setLevel(self.previous_level)
+        return False
+
+
+class TestSqliteTimelineDispatch(unittest.TestCase):
+    """A timeline row_type with no INSERT branch must not vanish.
+
+    `generate_sqlite`'s storage loop grew a final else that counts and reports what it
+    cannot place. The timeline loop had no such else, so an artifact whose row_type no
+    branch matched was dropped with nothing said -- the same defect, in the dispatcher
+    that did not get the fix.
+    """
+
+    def _write(self, row_types):
+        session = AnalysisSession.__new__(AnalysisSession)
+        session.parsed_artifacts = []
+        session.parsed_storage = []
+        session.parsed_extension_data = []
+        session.parsed_sync_data = []
+        session.preferences = []
+        session.installed_extensions = []
+
+        for row_type in row_types:
+            item = Chrome.PreferenceItem(
+                '/profile', url='abcdefghijklmnopabcdefghijklmnop',
+                timestamp=datetime.datetime(2026, 1, 1), key='An Extension [abc]',
+                value='Install source: unpacked', interpretation='')
+            item.row_type = row_type
+            item.source_item = 'Secure Preferences'
+            session.parsed_artifacts.append(item)
+
+        # NamedTemporaryFile/TemporaryDirectory cannot clean up a file sqlite3 still
+        # holds open on Windows, so the path is built by hand and removed best-effort.
+        directory = tempfile.mkdtemp()
+        db_path = os.path.join(directory, 'output.sqlite')
+        with _ErrorCapture() as captured:
+            session.generate_sqlite(db_path)
+
+        connection = sqlite3.connect(db_path)
+        try:
+            written = [row[0] for row in connection.execute('SELECT type FROM timeline')]
+        finally:
+            connection.close()
+        return written, captured.messages
+
+    def test_extension_install_events_reach_the_timeline_table(self):
+        # get_extension_settings appends `extension (installed)` / `(updated)` to
+        # parsed_artifacts, and the XLSX writer has a branch for them. The SQLite
+        # timeline had none, so every extension install and update event was dropped.
+        written, _ = self._write(['extension (installed)', 'extension (updated)'])
+
+        self.assertEqual(
+            ['extension (installed)', 'extension (updated)'], sorted(written))
+
+    def test_an_unhandled_row_type_is_reported_rather_than_dropped_silently(self):
+        written, errors = self._write(['a row_type no branch handles'])
+
+        self.assertEqual([], written)
+        matching = [m for m in errors if 'a row_type no branch handles' in m]
+        self.assertTrue(matching, errors)
+        self.assertIn('MISSING from the SQLite timeline table', matching[0])
+
+    def test_unhandled_rows_are_counted_not_reported_once_each(self):
+        # The storage loop reports one line per row_type with a count; the timeline
+        # loop matches it, so a million dropped rows are one line, not a million.
+        written, errors = self._write(['unknown kind'] * 3)
+
+        matching = [m for m in errors if 'unknown kind' in m]
+        self.assertEqual(1, len(matching), errors)
+        self.assertIn('3 "unknown kind"', matching[0])
+
+    def test_a_handled_row_type_is_not_reported_as_missing(self):
+        written, errors = self._write(['preference', 'site setting'])
+
+        self.assertEqual(2, len(written))
+        self.assertEqual(
+            [], [m for m in errors if 'MISSING from the SQLite timeline' in m], errors)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Towards #343.

### Scope — most of that issue is already fixed

Reading the code against the issue, three of its four parts have landed since it was written:

| Issue item | State on `main` |
| --- | --- |
| `HindsightEncoder.default()` dispatches on `Chrome.X`, so Firefox siblings fall through | **Fixed** — the chain tests `WebBrowser.X` |
| Service Worker classes have no encoder branch | **Fixed** — all five `ServiceWorker*Item` branches exist |
| JSONL drop is invisible | **Fixed** — `warn_unhandled()` reports class and derived `data_type` |
| `generate_sqlite()` storage loop has no else | **Fixed** — `unhandled_storage` counter, and a `service worker` INSERT branch |

What is left is the one the issue names but that did not get the fix: *"both dispatchers need a final else that logs"*. The **storage** loop got its else. The **timeline** loop did not.

### The live drop it is hiding

This is not only a defensive change. `get_extension_settings` appends `extension (installed)` and `extension (updated)` items to `parsed_artifacts` (`chrome.py:2414`), and the XLSX writer has a branch for them (`analysis.py:1952`). The SQLite timeline dispatch has neither a branch nor an else, so those events are dropped.

Measured on `main`, feeding two such items through `generate_sqlite`:

```
parsed_artifacts: ['extension (installed)', 'extension (updated)']
SELECT type FROM timeline  ->  []
```

Same shape as the Service Worker case the issue measured: parsed correctly, counted correctly, reported by the run, and then never written — so anyone working from SQLite has no indication the artifact exists.

### The change

- `extension` joins the `preference` / `site setting` / `notification` / … branch, whose column set it already fits (`PreferenceItem`, and the XLSX branch writes exactly these fields).
- A final `else` counting into `unhandled_timeline`, reported one line per row_type with a count, mirroring `unhandled_storage` exactly.

The `else` is the more important half. The branch fixes the one artifact missing today; the `else` is what makes the next one a reported number rather than a silent absence.

### Verification

Four tests driving `generate_sqlite` against a real on-disk SQLite file and reading the rows back. Three fail on `main`:

```
FAILED test_extension_install_events_reach_the_timeline_table
FAILED test_an_unhandled_row_type_is_reported_rather_than_dropped_silently
FAILED test_unhandled_rows_are_counted_not_reported_once_each
```

The fourth pins that a handled row_type is *not* reported as missing, so the else cannot start crying wolf.

Full suite on this branch: **243 passed, 2 skipped, 80 subtests passed**. Python 3.12.4.

### Not done here

I have deliberately left #343 open rather than closing it, because two of its questions are yours to settle and are not answered by this:

- whether the SQLite storage table should hold Service Worker rows or get its own table (they are in `storage` today);
- whether Service Worker JSONL rows should keep borrowing `chrome:local_storage:entry`-style `data_type` names — they currently use `chrome:service_worker:*`, which reads correct to me, but you flagged the collection they live in rather than the names.

Happy to take either on separately.