### PR TITLE
Add a contributing guide, mostly about the corpus tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,139 @@
+# Contributing to Hindsight
+
+Thanks for helping. This file covers how to get set up, how to run the tests, and one
+thing that is easy to miss: Hindsight has two test suites, and the second one runs
+against several gigabytes of real browser profiles that are not in this repository.
+
+## Getting set up
+
+Python 3.11 or newer. The floor is 3.11 because `pyhindsight.utils` uses
+`datetime.UTC`, which does not exist before it.
+
+```
+git clone https://github.com/RyanDFIR/hindsight.git
+cd hindsight
+pip install -r requirements.txt --group test
+```
+
+## The two test suites
+
+**Unit tests** are fast, self-contained and need no setup. No network, no platform
+guards, and every fixture is committed under `tests/fixtures`:
+
+```
+pytest tests/
+```
+
+**Corpus tests** parse whole browser profiles end to end and compare the result to
+committed baselines. They are the ones that catch schemas from 2018, half-written
+LevelDBs, and databases missing a column the query names. They need the corpus, and
+without it they skip:
+
+```
+pytest tests/test_corpus_e2e.py
+...
+SKIPPED [1] set HINDSIGHT_TEST_CORPUS to a corpus directory
+3 passed, 2 skipped
+```
+
+That skip is deliberate, so that `pytest tests/` stays green for someone who has not
+downloaded 6 GB of profiles. The trap is that a green local run does not mean the corpus
+tests passed, because they never ran. CI runs them on every pull request, including from
+forks, so a change that moves a baseline shows up there whether or not you saw it
+locally.
+
+## Getting the corpus
+
+The corpus is published as release assets on a public repository, so there is no token
+and no secret involved and nothing to ask for:
+
+<https://github.com/RyanDFIR/data-sets/releases/tag/corpus-v1>
+
+Six roots, one `.tar.gz` each, about 3 GB to download and 5.9 GB extracted:
+
+| Root | Profiles |
+| --- | --- |
+| `bf4sa_2025_bob-1` | 2 Chrome |
+| `bf4sa_2026_bob-2` | 2 Chrome |
+| `magnet.ctf_2018` | 2 Chrome, 2 Firefox |
+| `magnet.ctf_2019` | 2 Chrome |
+| `magnet.ctf_2020` | 1 Chrome |
+| `magnet.ctf_2023` | 4 Chrome, 1 Edge |
+
+The `bf4sa` roots are a synthetic persona built for training material. The `magnet` roots
+are Magnet Forensics CTF images. Saved passwords and cookie values in them are
+DPAPI-encrypted and bound to the machine that created them, so they cannot be read out of
+these archives.
+
+Extract every root you want into one directory. You do not need all six; the suite tests
+whichever baselines match the roots it finds.
+
+```
+mkdir corpus
+curl -L -o magnet.ctf_2018.tar.gz \
+  https://github.com/RyanDFIR/data-sets/releases/download/corpus-v1/magnet.ctf_2018.tar.gz
+tar -xzf magnet.ctf_2018.tar.gz -C corpus
+```
+
+`SHA256SUMS` in the same release lists the checksums. `tar` and `curl` ship with Windows
+10 and later, so the commands above work in PowerShell as written.
+
+Then point the suite at the directory holding the roots:
+
+```
+HINDSIGHT_TEST_CORPUS=/path/to/corpus pytest tests/test_corpus_e2e.py
+```
+
+PowerShell:
+
+```
+$env:HINDSIGHT_TEST_CORPUS = "D:\path\to\corpus"; pytest tests/test_corpus_e2e.py
+```
+
+To run a single root, because you only downloaded one or because you are narrowing a
+failure. One root takes a few seconds where all six take a few minutes:
+
+```
+HINDSIGHT_TEST_CORPUS=/path/to/corpus HINDSIGHT_TEST_CORPUS_ROOTS=magnet.ctf_2018 \
+  pytest tests/test_corpus_e2e.py
+```
+
+## When your change moves a baseline
+
+A corpus failure is not automatically a bug. It says parse output changed, and someone
+has to say which of the two it was:
+
+```
+magnet.ctf_2018 no longer parses to its baseline:
+  ...Default: Extensions count 3 -> 4
+  ...Default: Extensions status partial -> None
+```
+
+If the change is what you intended, because you fixed a parser and it now recovers
+records it used to miss, regenerate the baseline for that root and commit it alongside
+the code:
+
+```
+python tests/corpus/generate_baselines.py magnet.ctf_2018
+```
+
+Then say in the commit message what moved and why. The whole value of these files is that
+they make an unintended change visible, so regenerating on autopilot to turn a build green
+throws away the thing they are for. If a baseline moved and you cannot explain why, that
+is the bug.
+
+If you would rather not download several gigabytes, that is fine. Say in the pull request
+that you did not run the corpus tests, and a maintainer will regenerate any baseline your
+change moves.
+
+## Opening a pull request
+
+A few things that make review quick:
+
+* One issue per pull request.
+* A test that fails without your fix. If the fix is a pin for behaviour that already
+  works, say so rather than implying it caught something.
+* Say what you verified and what you did not. "I could not run the corpus" is useful
+  information, and no one will hold it against you.
+* Plain prose in the description. Say what was wrong, what you changed, and how you
+  checked it. Headings and tables are rarely needed for a change of a few dozen lines.

--- a/README.md
+++ b/README.md
@@ -94,3 +94,8 @@ The Chrome default profile folder default locations are:
 ## Feature Requests
 
 Please [file an issue](https://github.com/RyanDFIR/hindsight/issues/new/choose) if you have an idea for a new feature (or spotted something broken).
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to set up, run the two test suites, and get
+the browser profile corpus the end-to-end tests parse.


### PR DESCRIPTION
Nothing in the repo tells a contributor that a second test suite exists, that it needs several gigabytes of browser profiles that are not committed here, or that the corpus is published openly and takes no token to fetch. Two recent pull requests moved the magnet.ctf_2018 baseline without touching it, which is what that gap looks like from the outside.

CONTRIBUTING.md covers setup, the split between the unit suite and the corpus suite, where the corpus lives and how to point the tests at one root or all six, and what to do when a change moves a baseline. It repeats the rule from generate_baselines.py: regenerate deliberately and say what moved, never to turn a build green. It also says that skipping the corpus is fine as long as the pull request says so, since nobody is going to pull 6 GB for a one line fix.

The part worth writing down is the skip. A green `pytest tests/` says nothing about the corpus tests, because without HINDSIGHT_TEST_CORPUS they never ran.

README gets a link to it under Feature Requests.

I checked the instructions rather than only writing them: the download URL returns 200, the quoted skip message is what the suite actually prints, and `HINDSIGHT_TEST_CORPUS_ROOTS=magnet.ctf_2018` selects the one root and finishes in about five seconds.

One bullet in the pull request section is a preference rather than existing policy, the one about keeping descriptions in plain prose. Drop it if you would rather not put that in writing.
