### PR TITLE
Say how to install ccl_chromium_reader instead of failing with a traceback

### DIFF
--- a/hindsight.py
+++ b/hindsight.py
@@ -17,11 +17,22 @@ import shutil
 import sys
 import time
 
-import pyhindsight
-import pyhindsight.plugins
-from pyhindsight.analysis import AnalysisSession
-from pyhindsight.artifact_filter import ArtifactFilter, UnknownArtifactError, format_catalog
-from pyhindsight.utils import get_rich_banner, make_stdout_resilient
+# ccl_chromium_reader cannot be a declared dependency (PyPI rejects direct-URL
+# metadata), so a pip install can be missing it. chrome.py raises an ImportError
+# naming the install command; catching it here turns that into one line on
+# stderr instead of a traceback the user has to read past. See #331.
+try:
+    import pyhindsight
+    import pyhindsight.plugins
+    from pyhindsight.analysis import AnalysisSession
+    from pyhindsight.artifact_filter import ArtifactFilter, UnknownArtifactError, format_catalog
+    from pyhindsight.utils import get_rich_banner, make_stdout_resilient
+except ImportError as missing:
+    if "ccl_chromium_reader" not in str(missing):
+        raise
+    print(f"\n{missing}\n", file=sys.stderr)
+    sys.exit(1)
+
 
 import rich.align
 import rich.console

--- a/hindsight_gui.py
+++ b/hindsight_gui.py
@@ -6,10 +6,18 @@ import logging
 import warnings
 import bottle
 import importlib
-import pyhindsight
-import pyhindsight.plugins
-from pyhindsight.analysis import AnalysisSession
-from pyhindsight.utils import get_rich_banner, make_stdout_resilient
+# See the note in hindsight.py: ccl_chromium_reader cannot be a declared
+# dependency, so a pip install can be missing it (#331).
+try:
+    import pyhindsight
+    import pyhindsight.plugins
+    from pyhindsight.analysis import AnalysisSession
+    from pyhindsight.utils import get_rich_banner, make_stdout_resilient
+except ImportError as missing:
+    if "ccl_chromium_reader" not in str(missing):
+        raise
+    print(f"\n{missing}\n", file=sys.stderr)
+    sys.exit(1)
 import rich.align
 import rich.console
 

--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -15,7 +15,26 @@ import logging
 import shutil
 import puremagic
 import base64
-import ccl_chromium_reader
+
+try:
+    import ccl_chromium_reader
+except ImportError as _ccl_import_error:  # pragma: no cover - install-shape dependent
+    # ccl_chromium_reader exists only as a git repo, and PyPI rejects metadata
+    # carrying direct-URL dependencies, so it cannot be listed in
+    # pyproject.toml's `dependencies` (see the comment there). A plain
+    # `pip install pyhindsight` therefore produces a package whose first use
+    # is a bare ModuleNotFoundError with no hint at the fix -- see #331.
+    #
+    # This does not fix the distribution problem. It replaces the traceback
+    # with the command that resolves it.
+    raise ImportError(
+        "Hindsight needs ccl_chromium_reader, which is not on PyPI and so cannot "
+        "be installed automatically. Install it with:\n\n"
+        "    pip install git+https://github.com/cclgroupltd/ccl_chromium_reader.git\n\n"
+        "Without it, cache, IndexedDB, Session Storage and Local Storage cannot be "
+        "parsed. The frozen release binaries already bundle it; only pip installs "
+        "need this step."
+    ) from _ccl_import_error
 
 from pyhindsight.browsers.webbrowser import (
     ParseFailures, WebBrowser, timeline_sort_key)


### PR DESCRIPTION
Refs #331 — **option 3 only**, and deliberately not a close.

The issue lists three options in preference order. 1 (ask CCL to publish to PyPI) and 2 (vendor it) are calls for the project to make, and neither is mine to decide. 3 is the "minimum hardening regardless of the choice", and it is worth having whichever way the other two go.

## Before

```
  File "…/hindsight.py", line 22, in <module>
    from pyhindsight.analysis import AnalysisSession
  File "…/pyhindsight/analysis.py", line 18, in <module>
    from pyhindsight.browsers.chrome import Chrome
  File "…/pyhindsight/browsers/chrome.py", line 18, in <module>
    import ccl_chromium_reader
ImportError: No module named 'ccl_chromium_reader'
```

## After

```
Hindsight needs ccl_chromium_reader, which is not on PyPI and so cannot be
installed automatically. Install it with:

    pip install git+https://github.com/cclgroupltd/ccl_chromium_reader.git

Without it, cache, IndexedDB, Session Storage and Local Storage cannot be
parsed. The frozen release binaries already bundle it; only pip installs need
this step.

[exited with code 1]
```

No traceback, exit 1.

## How

`chrome.py`'s import raises an `ImportError` carrying the command, and both entry points (`hindsight.py`, `hindsight_gui.py`) catch **that one** error and exit with the message alone. Any other `ImportError` is re-raised untouched, so a genuinely broken install still shows its own traceback rather than being mislabelled as a missing ccl.

The message says the release binaries already bundle it, because otherwise the natural next question is "then why does the exe work?".

## Verified

Reproducing the pip-install-without-ccl shape on a machine that *has* ccl, via a `sys.meta_path` finder that makes the module unimportable, then importing each entry point:

| | before | after |
| --- | --- | --- |
| `import hindsight` | 6-frame traceback ending in `ImportError` | the message above, exit 1 |
| `import hindsight_gui` | same | same |
| with ccl present | imports fine | imports fine, `main` callable |

`pytest`: **248 passed, 2 skipped, 80 subtests passed** — unchanged.

## What this does not do

Left open on purpose, and why the issue should stay open:

- The dependency is still undeclared, so `pip install pyhindsight` still needs a second command. That is options 1 and 2.
- ccl's 43 bare `print()` calls are still worked around by the stdout guard rather than fixed, and `ccl_chromium_sessionstorage`'s `None` logger is still monkeypatched at runtime. Both need the control that only vendoring or an upstream change gives.

Happy to do the vendoring in a follow-up if that is the direction you want — including the sync script in the manner of `regen-protos.sh` — but that wants your decision first, not a PR that assumes it.
