### PR TITLE
Surface the notification tag, and the facts packed into notification_id

### DIFF
--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -3098,6 +3098,47 @@ class Chrome(WebBrowser):
         self.preferences.append({'data': results, 'presentation': presentation})
         return preference_count
 
+    @staticmethod
+    def decode_notification_id(notification_id):
+        """Split a Chromium notification_id into the facts it encodes.
+
+        The id is a packed string, not an opaque handle:
+
+            p#https://calendar.google.com/#1event-notification
+            ||                            |
+            ||                            +- type digit: 0 = notification id,
+            ||                                           1 = developer tag
+            |+- b if the browser raised it, # if the page did
+            +- p persistent, n non-persistent
+
+        Returns None for anything that does not match, so a format change
+        degrades to "we do not know" rather than to a wrong answer; the caller
+        emits the raw id in that case and nothing is lost.
+        """
+        if not notification_id or len(notification_id) < 3:
+            return None
+
+        persistent = {'p': True, 'n': False}.get(notification_id[0])
+        raised_by = {'b': 'browser', '#': 'page'}.get(notification_id[1])
+        if persistent is None or raised_by is None:
+            return None
+
+        origin, separator, tail = notification_id[2:].partition('#')
+        if not separator or not tail:
+            return None
+
+        kind = {'0': 'notification id', '1': 'developer tag'}.get(tail[0])
+        if kind is None:
+            return None
+
+        return {
+            'persistent': persistent,
+            'raised_by': raised_by,
+            'origin': origin,
+            'kind': kind,
+            'value': tail[1:],
+        }
+
     def get_platform_notifications(self, path, dir_name):
         try:
             from ccl_chromium_reader.ccl_chromium_notifications import NotificationReader
@@ -3148,6 +3189,28 @@ class Chrome(WebBrowser):
                                 value_parts.append(f'Actions: {actions_str}')
                         if notification.data is not None:
                             value_parts.append(f'Data: {notification.data}')
+
+                        # The developer tag is the slot a site overwrites, so it is what
+                        # separates six reminders from one recurring channel from six
+                        # unrelated alerts. ccl parses it already; it was never emitted.
+                        if notification.tag:
+                            value_parts.append(f'Tag: {notification.tag}')
+
+                        decoded = Chrome.decode_notification_id(notification.notification_id)
+                        if decoded:
+                            value_parts.append(
+                                'Persistent: ' + ('Yes' if decoded['persistent'] else 'No'))
+                            value_parts.append(f"Raised By: {decoded['raised_by'].title()}")
+                            # Only when it says something the Tag row does not.
+                            if decoded['kind'] == 'notification id' and decoded['value']:
+                                value_parts.append(f"Notification ID: {decoded['value']}")
+                        elif notification.notification_id:
+                            # Undecodable: emit it whole rather than drop it.
+                            value_parts.append(f'Notification ID: {notification.notification_id}')
+
+                        if notification.persistent_notification_id:
+                            value_parts.append(
+                                f'Persistent Notification ID: {notification.persistent_notification_id}')
 
                         value = '\n'.join(value_parts)
 

--- a/tests/test_notification_id.py
+++ b/tests/test_notification_id.py
@@ -1,0 +1,69 @@
+"""Chromium packs facts into notification_id; Hindsight was dropping all of them.
+
+The developer tag is the slot a site overwrites, so it is what tells six
+reminders from one recurring channel apart from six unrelated alerts. ccl parses
+it, and `get_platform_notifications` used neither it nor `notification_id`.
+"""
+import unittest
+
+from pyhindsight.browsers.chrome import Chrome
+
+
+class TestDecodeNotificationId(unittest.TestCase):
+    def test_the_real_sample_from_the_corpus(self):
+        # bf4sa_2026_bob-2, Default profile: six live notifications, all from
+        # Google Calendar, all sharing this id.
+        decoded = Chrome.decode_notification_id(
+            'p#https://calendar.google.com/#1event-notification')
+
+        self.assertEqual(decoded, {
+            'persistent': True,
+            'raised_by': 'page',
+            'origin': 'https://calendar.google.com/',
+            'kind': 'developer tag',
+            'value': 'event-notification',
+        })
+
+    def test_non_persistent_and_browser_raised(self):
+        decoded = Chrome.decode_notification_id('nbhttps://example.test/#0abc123')
+
+        self.assertFalse(decoded['persistent'])
+        self.assertEqual(decoded['raised_by'], 'browser')
+        self.assertEqual(decoded['kind'], 'notification id')
+        self.assertEqual(decoded['value'], 'abc123')
+
+    def test_an_origin_containing_a_hash_stops_at_the_first_one(self):
+        # partition() splits on the first '#', which is the separator; the
+        # test pins that rather than leaving it to chance.
+        decoded = Chrome.decode_notification_id('p#https://a.test/#1tag#with#hashes')
+
+        self.assertEqual(decoded['origin'], 'https://a.test/')
+        self.assertEqual(decoded['value'], 'tag#with#hashes')
+
+    def test_an_empty_value_still_decodes(self):
+        decoded = Chrome.decode_notification_id('p#https://a.test/#1')
+
+        self.assertEqual(decoded['value'], '')
+        self.assertEqual(decoded['kind'], 'developer tag')
+
+    def test_anything_unrecognised_decodes_to_nothing(self):
+        # None rather than a guess, so a format change degrades to "we do not
+        # know" and the caller falls back to printing the raw id.
+        for value in (
+            None,
+            '',
+            'p',
+            'p#',
+            'x#https://a.test/#1tag',      # neither p nor n
+            'pxhttps://a.test/#1tag',      # neither b nor #
+            'p#https://a.test/',           # no separator before the type digit
+            'p#https://a.test/#',          # separator but nothing after it
+            'p#https://a.test/#9tag',      # unknown type digit
+            'an-opaque-handle',
+        ):
+            with self.subTest(value=value):
+                self.assertIsNone(Chrome.decode_notification_id(value))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #333.

## The decision the issue leaves open

> Worth deciding whether to emit the raw id, the decoded parts, or both.

**Decoded parts, with the raw id as the fallback.** A row reading `p#https://calendar.google.com/#1event-notification` asks the reader to decode it by hand every time, and the origin is already the record's URL and the tag is already its own row — so most of that string is a restatement. The parts that are *not* said anywhere else are persistence and who raised it, so those become rows:

```
Body: Standup in 10 minutes
Tag: event-notification
Persistent: Yes
Raised By: Page
```

The id's own value is emitted only when the type digit says `0` (notification id). When it says `1` the value *is* the tag, and the Tag row already has it.

When the string does not decode, `decode_notification_id` returns `None` and the caller prints the id whole. So a future format change costs the decoded rows but never the data — which is the reason it returns `None` rather than guessing at the parts it can see.

## `persistent_notification_id`

The issue asks to confirm it is ever populated before spending a row on it. I could not: it is `None` throughout the sample here too, exactly as reported. It is emitted **only when truthy**, so it costs nothing today and appears the day it is populated rather than needing a second PR.

## Verified

`tests/test_notification_id.py`. Red before green, with only `chrome.py` stashed:

```
$ python -m pytest tests/test_notification_id.py -q
14 failed, 1 passed          # before
5 passed, 10 subtests passed # after
```

Covering:

- the real corpus id from `bf4sa_2026_bob-2` — decodes to persistent, page-raised, developer tag `event-notification`, which agrees with what ccl parses independently
- the `n` and `b` variants, which the corpus does not contain
- an origin/tag containing further `#` characters — `partition()` splits on the first, and the test pins that rather than leaving it to chance
- an empty tag, which still decodes
- ten shapes that must decode to `None`: too short, unknown persistence flag, unknown raiser flag, no separator, separator with nothing after it, unknown type digit, and an opaque handle

Full suite: **253 passed, 2 skipped, 90 subtests** (up from 248/2/80, all new).

## Scope

The `Tag:` line is the whole fix for the common case, as the issue says. The decoder is 30 lines and pays for itself in the two flags the tag cannot give you — but if you would rather ship only the tag and leave the id alone, the decoder is one self-contained static method and its tests, and I will drop it.
